### PR TITLE
Fix rasterization orientation and pixel mapping

### DIFF
--- a/hw1/main.cpp
+++ b/hw1/main.cpp
@@ -51,8 +51,8 @@ int main(int argc, char* argv[]) {
     color background_col{uint8_t(0), uint8_t(0),  uint8_t(0)};
     color draw_col      {uint8_t(255),  uint8_t(255), uint8_t(255)};
 
-    for(size_t i = 0; i < xres; ++i){
-        for(size_t j = 0; j < yres; ++j){
+    for(size_t j = 0; j < yres; ++j){
+        for(size_t i = 0; i < xres; ++i){
             bool anyVerts = false;
             for (const auto& vert : scene_objects_vertices) {
                 size_t pixelX = static_cast<size_t>(std::round(vert.x));

--- a/hw1/scene_types.h
+++ b/hw1/scene_types.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <Eigen/Dense>
+#include <cstdint>
 
 struct vertex {
     double x, y, z;

--- a/hw1/transform_utils.cpp
+++ b/hw1/transform_utils.cpp
@@ -95,12 +95,18 @@ std::vector<object> applyCameraTransformsToObjects(const std::vector<object>& ob
 
 std::vector<vertex> convertCoordsToPixels(std::vector<object> objects, size_t xres, size_t yres){
     std::vector<vertex> pixelCoords;
+    if (xres == 0 || yres == 0) return pixelCoords;
+
+    const double max_x = static_cast<double>(xres - 1);
+    const double max_y = static_cast<double>(yres - 1);
+
     for (const auto& obj : objects) {
-        for (const auto& vert : obj.vertices) {
+        for (std::size_t vi = 1; vi < obj.vertices.size(); ++vi) {
+            const auto& vert = obj.vertices[vi];
             if (vert.x < -1 || vert.x > 1 || vert.y < -1 || vert.y > 1 || vert.z < -1 || vert.z > 1) continue;
 
-            double pixelX = (vert.x + 1) / 2 * xres;
-            double pixelY = (vert.y + 1) / 2 * yres;
+            double pixelX = (vert.x + 1.0) * 0.5 * max_x;
+            double pixelY = (vert.y + 1.0) * 0.5 * max_y;
             pixelCoords.push_back(vertex({pixelX, pixelY, vert.z}));
         }
     }


### PR DESCRIPTION
## Summary
- render PPM images row-by-row to avoid transposing the output
- map NDC vertices to pixel coordinates using the correct resolution range and skip the sentinel vertex
- include <cstdint> so the color struct builds on all platforms

## Testing
- make -C hw1

------
https://chatgpt.com/codex/tasks/task_e_68e74b9d26f48322bcea1fe093ba04fa