### PR TITLE
Add OpenGL scene renderer with Arcball interaction

### DIFF
--- a/hw3/CMakeLists.txt
+++ b/hw3/CMakeLists.txt
@@ -1,10 +1,20 @@
 cmake_minimum_required(VERSION 3.24)
-project(hw0 LANGUAGES CXX)
+project(hw3 LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-project(hw1 LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
 find_package(GLEW REQUIRED)
-add_executable(opengl_demo opengl_demo.cpp)
-target_link_libraries(opengl_demo PRIVATE GLUT::GLUT GLEW::GLEW OpenGL::GL)
+
+add_executable(opengl_renderer
+    opengl_renderer.cpp
+    scene_loader.cpp)
+
+target_include_directories(opengl_renderer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../hw2
+    ${CMAKE_CURRENT_SOURCE_DIR}/../hw2/Eigen)
+
+target_link_libraries(opengl_renderer PRIVATE GLUT::GLUT GLEW::GLEW OpenGL::GL)

--- a/hw3/arcball.h
+++ b/hw3/arcball.h
@@ -1,0 +1,63 @@
+#ifndef HW3_ARCBALL_H
+#define HW3_ARCBALL_H
+
+#include "quaternion.h"
+
+#include <array>
+#include <cmath>
+
+class Arcball {
+public:
+    void set_window(int width, int height) {
+        window_width_ = width;
+        window_height_ = height;
+    }
+
+    void begin_drag(int x, int y) {
+        dragging_ = true;
+        start_vec_ = map_to_sphere(x, y);
+        base_rotation_ = current_rotation_;
+    }
+
+    void update_drag(int x, int y) {
+        if (!dragging_) return;
+        auto current_vec = map_to_sphere(x, y);
+        Quaternion delta = Quaternion::from_unit_vectors(start_vec_, current_vec);
+        current_rotation_ = delta * base_rotation_;
+    }
+
+    void end_drag() {
+        dragging_ = false;
+    }
+
+    Quaternion rotation() const { return current_rotation_; }
+
+private:
+    std::array<double,3> map_to_sphere(int x, int y) const {
+        if (window_width_ == 0 || window_height_ == 0) {
+            return {0.0, 0.0, 1.0};
+        }
+        double nx = (2.0 * x - window_width_) / window_width_;
+        double ny = (window_height_ - 2.0 * y) / window_height_;
+        double length = nx*nx + ny*ny;
+        double nz;
+        if (length > 1.0) {
+            double norm = std::sqrt(length);
+            nx /= norm;
+            ny /= norm;
+            nz = 0.0;
+        } else {
+            nz = std::sqrt(1.0 - length);
+        }
+        return {nx, ny, nz};
+    }
+
+    int window_width_{1};
+    int window_height_{1};
+    bool dragging_{false};
+    std::array<double,3> start_vec_{0.0, 0.0, 1.0};
+    Quaternion base_rotation_ = Quaternion::identity();
+    Quaternion current_rotation_ = Quaternion::identity();
+};
+
+#endif

--- a/hw3/opengl_renderer.cpp
+++ b/hw3/opengl_renderer.cpp
@@ -1,0 +1,243 @@
+#include "scene_loader.h"
+#include "arcball.h"
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
+#include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+struct DrawableObject {
+    std::vector<GLfloat> vertices;
+    std::vector<GLfloat> normals;
+    GLfloat ambient[4];
+    GLfloat diffuse[4];
+    GLfloat specular[4];
+    GLfloat shininess;
+};
+
+namespace {
+Scene g_scene;
+std::vector<DrawableObject> g_drawables;
+Arcball g_arcball;
+int g_window_width = 640;
+int g_window_height = 480;
+}
+
+void build_drawables() {
+    g_drawables.clear();
+    g_drawables.reserve(g_scene.scene_objects.size());
+
+    for (const auto& inst : g_scene.scene_objects) {
+        DrawableObject drawable;
+        drawable.vertices.reserve(inst.obj.faces.size() * 9);
+        drawable.normals.reserve(inst.obj.faces.size() * 9);
+
+        auto fill_material = [&](const Eigen::Vector3d& src, GLfloat out[4]) {
+            out[0] = static_cast<GLfloat>(src[0]);
+            out[1] = static_cast<GLfloat>(src[1]);
+            out[2] = static_cast<GLfloat>(src[2]);
+            out[3] = 1.0f;
+        };
+
+        fill_material(inst.ambient, drawable.ambient);
+        fill_material(inst.diffuse, drawable.diffuse);
+        fill_material(inst.specular, drawable.specular);
+        double shininess = std::clamp(inst.shininess * 128.0, 0.0, 128.0);
+        drawable.shininess = static_cast<GLfloat>(shininess);
+
+        for (const auto& face : inst.obj.faces) {
+            const Vertex& v1 = inst.obj.vertices.at(face.v1);
+            const Vertex& v2 = inst.obj.vertices.at(face.v2);
+            const Vertex& v3 = inst.obj.vertices.at(face.v3);
+            const Normal& n1 = inst.obj.normals.at(face.vn1);
+            const Normal& n2 = inst.obj.normals.at(face.vn2);
+            const Normal& n3 = inst.obj.normals.at(face.vn3);
+
+            const std::array<const Vertex*, 3> verts{&v1, &v2, &v3};
+            const std::array<const Normal*, 3> norms{&n1, &n2, &n3};
+
+            for (int i = 0; i < 3; ++i) {
+                drawable.normals.push_back(static_cast<GLfloat>(norms[i]->x));
+                drawable.normals.push_back(static_cast<GLfloat>(norms[i]->y));
+                drawable.normals.push_back(static_cast<GLfloat>(norms[i]->z));
+
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->x));
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->y));
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->z));
+            }
+        }
+
+        g_drawables.push_back(std::move(drawable));
+    }
+}
+
+void init_gl() {
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_LIGHTING);
+    glEnable(GL_NORMALIZE);
+    glShadeModel(GL_SMOOTH);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+}
+
+void set_lights() {
+    const auto& lights = g_scene.lights;
+    GLint max_lights = 0;
+    glGetIntegerv(GL_MAX_LIGHTS, &max_lights);
+
+    for (GLint i = 0; i < max_lights; ++i) {
+        GLenum light_id = static_cast<GLenum>(GL_LIGHT0 + i);
+        if (i < static_cast<GLint>(lights.size())) {
+            const auto& light = lights[i];
+            glEnable(light_id);
+            GLfloat position[4] = {
+                static_cast<GLfloat>(light.x),
+                static_cast<GLfloat>(light.y),
+                static_cast<GLfloat>(light.z),
+                1.0f
+            };
+            GLfloat color[4] = {
+                static_cast<GLfloat>(light.r),
+                static_cast<GLfloat>(light.g),
+                static_cast<GLfloat>(light.b),
+                1.0f
+            };
+            glLightfv(light_id, GL_POSITION, position);
+            glLightfv(light_id, GL_DIFFUSE, color);
+            glLightfv(light_id, GL_SPECULAR, color);
+            glLightf(light_id, GL_CONSTANT_ATTENUATION, 1.0f);
+            glLightf(light_id, GL_LINEAR_ATTENUATION, 0.0f);
+            glLightf(light_id, GL_QUADRATIC_ATTENUATION, static_cast<GLfloat>(light.atten));
+        } else {
+            glDisable(light_id);
+        }
+    }
+}
+
+void draw_scene() {
+    for (const auto& drawable : g_drawables) {
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, drawable.ambient);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, drawable.diffuse);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, drawable.specular);
+        glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, drawable.shininess);
+
+        glBegin(GL_TRIANGLES);
+        for (std::size_t i = 0; i < drawable.vertices.size(); i += 3) {
+            glNormal3f(drawable.normals[i], drawable.normals[i + 1], drawable.normals[i + 2]);
+            glVertex3f(drawable.vertices[i], drawable.vertices[i + 1], drawable.vertices[i + 2]);
+        }
+        glEnd();
+    }
+}
+
+void display() {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadMatrixd(g_scene.cam_transforms.P.data());
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glMultMatrixd(g_scene.cam_transforms.Cinv.data());
+    auto arcball_matrix = g_arcball.rotation().to_matrix();
+    glMultMatrixd(arcball_matrix.data());
+
+    set_lights();
+    draw_scene();
+
+    glutSwapBuffers();
+}
+
+void reshape(int width, int height) {
+    g_window_width = std::max(width, 1);
+    g_window_height = std::max(height, 1);
+    glViewport(0, 0, g_window_width, g_window_height);
+    g_arcball.set_window(g_window_width, g_window_height);
+    glutPostRedisplay();
+}
+
+void mouse(int button, int state, int x, int y) {
+    if (button == GLUT_LEFT_BUTTON) {
+        if (state == GLUT_DOWN) {
+            g_arcball.begin_drag(x, y);
+        } else if (state == GLUT_UP) {
+            g_arcball.end_drag();
+        }
+        glutPostRedisplay();
+    }
+}
+
+void motion(int x, int y) {
+    g_arcball.update_drag(x, y);
+    glutPostRedisplay();
+}
+
+void keyboard(unsigned char key, int, int) {
+    if (key == 27 || key == 'q' || key == 'Q') {
+        std::exit(0);
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        std::cerr << "Usage: " << argv[0] << " [scene_description_file.txt] [xres] [yres]\n";
+        return 1;
+    }
+
+    const std::size_t xres = parse_size_t(argv[2]);
+    const std::size_t yres = parse_size_t(argv[3]);
+
+    std::ifstream fin(argv[1]);
+    if (!fin) {
+        std::cerr << "Could not open file: " << argv[1] << "\n";
+        return 1;
+    }
+
+    try {
+        g_scene = parse_scene_file(fin, parse_parent_path(argv[1]));
+    } catch (const std::exception& e) {
+        std::cerr << "Error parsing scene: " << e.what() << "\n";
+        return 1;
+    }
+
+    g_window_width = static_cast<int>(xres);
+    g_window_height = static_cast<int>(yres);
+    g_arcball.set_window(g_window_width, g_window_height);
+
+    build_drawables();
+
+    glutInit(&argc, argv);
+    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+    glutInitWindowSize(g_window_width, g_window_height);
+    glutCreateWindow("OpenGL Scene Renderer");
+
+    GLenum err = glewInit();
+    if (err != GLEW_OK) {
+        std::cerr << "GLEW init error: " << glewGetErrorString(err) << "\n";
+        return 1;
+    }
+
+    init_gl();
+
+    glutDisplayFunc(display);
+    glutReshapeFunc(reshape);
+    glutMouseFunc(mouse);
+    glutMotionFunc(motion);
+    glutKeyboardFunc(keyboard);
+
+    glutMainLoop();
+    return 0;
+}
+

--- a/hw3/quaternion.h
+++ b/hw3/quaternion.h
@@ -1,0 +1,86 @@
+#ifndef HW3_QUATERNION_H
+#define HW3_QUATERNION_H
+
+#include <array>
+#include <cmath>
+
+struct Quaternion {
+    double w{1.0};
+    double x{0.0};
+    double y{0.0};
+    double z{0.0};
+
+    Quaternion() = default;
+    Quaternion(double w_, double x_, double y_, double z_)
+        : w(w_), x(x_), y(y_), z(z_) {}
+
+    static Quaternion identity() { return Quaternion(); }
+
+    static Quaternion from_axis_angle(double axis_x, double axis_y, double axis_z, double angle) {
+        double half = angle * 0.5;
+        double s = std::sin(half);
+        return Quaternion(std::cos(half), axis_x * s, axis_y * s, axis_z * s);
+    }
+
+    static Quaternion from_unit_vectors(const std::array<double,3>& from,
+                                        const std::array<double,3>& to) {
+        double dot = from[0]*to[0] + from[1]*to[1] + from[2]*to[2];
+        std::array<double,3> cross{
+            from[1]*to[2] - from[2]*to[1],
+            from[2]*to[0] - from[0]*to[2],
+            from[0]*to[1] - from[1]*to[0]
+        };
+        Quaternion q(dot + 1.0, cross[0], cross[1], cross[2]);
+        if (q.length_squared() < 1e-12) {
+            // Vectors are nearly opposite; choose arbitrary orthogonal axis
+            std::array<double,3> ortho = std::abs(from[0]) < 0.9 ?
+                std::array<double,3>{0.0, -from[2], from[1]} :
+                std::array<double,3>{-from[1], from[0], 0.0};
+            double norm = std::sqrt(ortho[0]*ortho[0] + ortho[1]*ortho[1] + ortho[2]*ortho[2]);
+            ortho[0] /= norm; ortho[1] /= norm; ortho[2] /= norm;
+            return Quaternion(0.0, ortho[0], ortho[1], ortho[2]);
+        }
+        return q.normalized();
+    }
+
+    Quaternion normalized() const {
+        double len = std::sqrt(length_squared());
+        if (len == 0.0) return Quaternion();
+        return Quaternion(w / len, x / len, y / len, z / len);
+    }
+
+    double length_squared() const {
+        return w*w + x*x + y*y + z*z;
+    }
+
+    Quaternion operator*(const Quaternion& rhs) const {
+        return Quaternion(
+            w*rhs.w - x*rhs.x - y*rhs.y - z*rhs.z,
+            w*rhs.x + x*rhs.w + y*rhs.z - z*rhs.y,
+            w*rhs.y - x*rhs.z + y*rhs.w + z*rhs.x,
+            w*rhs.z + x*rhs.y - y*rhs.x + z*rhs.w
+        );
+    }
+
+    std::array<double,16> to_matrix() const {
+        Quaternion n = normalized();
+        double xx = n.x * n.x;
+        double yy = n.y * n.y;
+        double zz = n.z * n.z;
+        double xy = n.x * n.y;
+        double xz = n.x * n.z;
+        double yz = n.y * n.z;
+        double wx = n.w * n.x;
+        double wy = n.w * n.y;
+        double wz = n.w * n.z;
+
+        return {
+            1.0 - 2.0*(yy + zz), 2.0*(xy - wz),       2.0*(xz + wy),       0.0,
+            2.0*(xy + wz),       1.0 - 2.0*(xx + zz), 2.0*(yz - wx),       0.0,
+            2.0*(xz - wy),       2.0*(yz + wx),       1.0 - 2.0*(xx + yy), 0.0,
+            0.0,                 0.0,                 0.0,                 1.0
+        };
+    }
+};
+
+#endif

--- a/hw3/scene_loader.cpp
+++ b/hw3/scene_loader.cpp
@@ -1,0 +1,433 @@
+#include "scene_loader.h"
+
+#include <Eigen/Geometry>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Matrix4d;
+using Eigen::Vector3d;
+
+namespace {
+std::string join_path(const std::string& parent, const std::string& filename) {
+    if (parent.empty()) return filename;
+    if (parent.back() == '/' || parent.back() == '\\') return parent + filename;
+    return parent + "/" + filename;
+}
+
+Matrix4d make_translation(double tx, double ty, double tz) {
+    Matrix4d T = Matrix4d::Identity();
+    T(0, 3) = tx;
+    T(1, 3) = ty;
+    T(2, 3) = tz;
+    return T;
+}
+
+Matrix4d make_scaling(double sx, double sy, double sz) {
+    Matrix4d S = Matrix4d::Identity();
+    S(0, 0) = sx;
+    S(1, 1) = sy;
+    S(2, 2) = sz;
+    return S;
+}
+
+Matrix4d make_rotation(double rx, double ry, double rz, double angle) {
+    Vector3d axis(rx, ry, rz);
+    if (axis.norm() == 0.0) {
+        return Matrix4d::Identity();
+    }
+    axis.normalize();
+    Matrix3d R3 = AngleAxisd(angle, axis).toRotationMatrix();
+    Matrix4d R = Matrix4d::Identity();
+    R.block<3,3>(0,0) = R3;
+    return R;
+}
+
+void apply_transform_to_object(Object& src, const Matrix4d& M, bool transform_normals = true) {
+    for (std::size_t vi = 1; vi < src.vertices.size(); ++vi) {
+        auto& v = src.vertices[vi];
+        Eigen::Vector4d p(v.x, v.y, v.z, 1.0);
+        Eigen::Vector3d q = (M * p).hnormalized();
+        v.x = q[0];
+        v.y = q[1];
+        v.z = q[2];
+    }
+
+    if (transform_normals) {
+        const Matrix3d A = M.block<3,3>(0,0);
+        Matrix3d N;
+        double det = A.determinant();
+        if (std::abs(det) < 1e-15) {
+            N = Matrix3d::Identity();
+        } else {
+            N = A.inverse().transpose();
+        }
+
+        for (std::size_t ni = 1; ni < src.normals.size(); ++ni) {
+            auto& vn = src.normals[ni];
+            Eigen::Vector3d n(vn.x, vn.y, vn.z);
+            n = N * n;
+            n.normalize();
+            vn.x = n.x();
+            vn.y = n.y();
+            vn.z = n.z();
+        }
+    }
+}
+
+Matrix4d make_transform_from_lines(const std::vector<std::string>& lines) {
+    Matrix4d M = Matrix4d::Identity();
+    std::size_t lineno = 0;
+
+    for (const auto& raw_line : lines) {
+        ++lineno;
+        auto first_non_ws = raw_line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw_line[first_non_ws] == '#') continue;
+
+        std::istringstream iss(raw_line.substr(first_non_ws));
+        char kind;
+        iss >> kind;
+        if (!iss) continue;
+
+        Matrix4d T = Matrix4d::Identity();
+        if (kind == 't') {
+            double tx, ty, tz;
+            if (!(iss >> tx >> ty >> tz)) {
+                throw std::runtime_error("Invalid translation at line " + std::to_string(lineno));
+            }
+            T = make_translation(tx, ty, tz);
+        } else if (kind == 's') {
+            double sx, sy, sz;
+            if (!(iss >> sx >> sy >> sz)) {
+                throw std::runtime_error("Invalid scale at line " + std::to_string(lineno));
+            }
+            T = make_scaling(sx, sy, sz);
+        } else if (kind == 'r') {
+            double rx, ry, rz, angle;
+            if (!(iss >> rx >> ry >> rz >> angle)) {
+                throw std::runtime_error("Invalid rotation at line " + std::to_string(lineno));
+            }
+            T = make_rotation(rx, ry, rz, angle);
+        }
+
+        M = T * M;
+    }
+
+    return M;
+}
+
+std::size_t find_string_idx(
+    const std::string& name,
+    const std::unordered_map<std::string, std::size_t>& name_to_idx) {
+    auto it = name_to_idx.find(name);
+    if (it == name_to_idx.end()) {
+        throw std::out_of_range("Name not found: " + name);
+    }
+    return it->second;
+}
+
+std::vector<Object> load_objects(const std::vector<std::string>& fpaths,
+                                 const std::string& parent_path) {
+    std::vector<Object> objects;
+    for (const auto& filename : fpaths) {
+        std::string file_path = join_path(parent_path, filename);
+        std::ifstream file(file_path);
+        if (!file) {
+            throw std::runtime_error("Error: Could not open file " + file_path);
+        }
+
+        std::vector<Vertex> vertices{{0.0, 0.0, 0.0}};
+        std::vector<Normal> normals{{0.0, 0.0, 0.0}};
+        std::vector<Face> faces;
+        std::string line;
+
+        while (std::getline(file, line)) {
+            auto first_non_ws = line.find_first_not_of(" \t\r\n");
+            if (first_non_ws == std::string::npos) continue;
+            if (line[first_non_ws] == '#') continue;
+
+            std::istringstream line_stream(line.substr(first_non_ws));
+            std::string type;
+            line_stream >> type;
+
+            if (type == "v") {
+                double x, y, z;
+                if (!(line_stream >> x >> y >> z)) {
+                    throw std::runtime_error("Invalid vertex format");
+                }
+                vertices.push_back({x, y, z});
+            } else if (type == "vn") {
+                double x, y, z;
+                if (!(line_stream >> x >> y >> z)) {
+                    throw std::runtime_error("Invalid normal format");
+                }
+                normals.push_back({x, y, z});
+            } else if (type == "f") {
+                unsigned int v_idx[3], n_idx[3];
+                for (int i = 0; i < 3; ++i) {
+                    std::string token;
+                    if (!(line_stream >> token)) {
+                        throw std::runtime_error("Invalid face format");
+                    }
+                    auto pos = token.find("//");
+                    if (pos == std::string::npos) {
+                        throw std::runtime_error("Expected 'v//vn' format");
+                    }
+                    v_idx[i] = static_cast<unsigned int>(std::stoul(token.substr(0, pos)));
+                    n_idx[i] = static_cast<unsigned int>(std::stoul(token.substr(pos + 2)));
+                }
+                faces.push_back({v_idx[0], v_idx[1], v_idx[2], n_idx[0], n_idx[1], n_idx[2]});
+            }
+        }
+
+        objects.push_back({file_path, std::move(vertices), std::move(normals), std::move(faces)});
+    }
+
+    return objects;
+}
+
+std::size_t parse_object_mappings(const std::vector<std::string>& lines,
+                                  std::vector<std::string>& object_names,
+                                  std::vector<std::string>& object_paths) {
+    bool started_mapping = false;
+    std::size_t i = 0;
+
+    for (; i < lines.size(); ++i) {
+        const std::string& line = lines[i];
+        auto first_non_ws = line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            if (started_mapping) { ++i; break; }
+            continue;
+        }
+        if (line[first_non_ws] == '#') continue;
+
+        started_mapping = true;
+        std::istringstream iss(line.substr(first_non_ws));
+        std::string name, path;
+        if (!(iss >> name >> path)) {
+            throw std::runtime_error("Invalid object mapping: " + line);
+        }
+        object_names.push_back(name);
+        object_paths.push_back(path);
+    }
+
+    return i;
+}
+
+void process_transform_blocks(const std::vector<std::string>& lines,
+                              std::size_t start_idx,
+                              std::vector<Object>& objects,
+                              const std::vector<std::string>& object_names,
+                              const std::unordered_map<std::string, std::size_t>& name_to_idx,
+                              std::vector<ObjectInstance>& out_transformed) {
+    if (objects.size() != object_names.size()) {
+        throw std::runtime_error("Mismatched object counts");
+    }
+
+    std::unordered_map<std::string, std::size_t> copy_count;
+    std::string current_name;
+    std::vector<std::string> current_transform_lines;
+    Eigen::Vector3d current_ambient = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_diffuse = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_specular = Eigen::Vector3d::Zero();
+    double current_shininess = 0.0;
+
+    auto flush_instance = [&]() {
+        if (current_name.empty() || current_transform_lines.empty()) {
+            current_transform_lines.clear();
+            return;
+        }
+        std::size_t base_idx = find_string_idx(current_name, name_to_idx);
+        Matrix4d M = make_transform_from_lines(current_transform_lines);
+        auto base = objects.at(base_idx);
+        apply_transform_to_object(base, M);
+        std::size_t n = ++copy_count[current_name];
+        std::string out_name = current_name + "_copy" + std::to_string(n);
+        out_transformed.emplace_back(ObjectInstance{std::move(base), out_name,
+            current_ambient, current_diffuse, current_specular, current_shininess});
+        current_name.clear();
+        current_transform_lines.clear();
+        current_ambient.setZero();
+        current_diffuse.setZero();
+        current_specular.setZero();
+        current_shininess = 0.0;
+    };
+
+    for (std::size_t i = start_idx; i < lines.size(); ++i) {
+        const std::string& tline = lines[i];
+        auto first_non_ws = tline.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            flush_instance();
+            continue;
+        }
+        if (tline[first_non_ws] == '#') continue;
+
+        std::istringstream iss(tline.substr(first_non_ws));
+        std::string tok;
+        iss >> tok;
+        if (!iss && tok.empty()) continue;
+
+        if (tok == "ambient") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_ambient = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "diffuse") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_diffuse = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "specular") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_specular = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "shininess") {
+            if (current_name.empty()) continue;
+            double s = 0; iss >> s;
+            current_shininess = s;
+            continue;
+        }
+
+        if (tok == "t" || tok == "r" || tok == "s") {
+            if (current_name.empty()) continue;
+            current_transform_lines.push_back(tline.substr(first_non_ws));
+            continue;
+        }
+
+        flush_instance();
+        current_name = tok;
+    }
+
+    flush_instance();
+}
+
+void read_cam_params_and_lights(CameraParams& cam, std::vector<Light>& lights, std::ifstream& fin) {
+    std::string raw;
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+
+        if (line == "objects:") {
+            break;
+        }
+
+        std::istringstream iss(line);
+        std::string key; iss >> key;
+
+        if (key == "light") {
+            double x, y, z, r, g, b, atten;
+            char comma;
+            if (!(iss >> x >> y >> z >> comma >> r >> g >> b >> comma >> atten)) {
+                throw std::runtime_error("Invalid light format");
+            }
+            lights.push_back({x, y, z, r, g, b, atten});
+        } else if (key == "position") {
+            iss >> cam.px >> cam.py >> cam.pz;
+        } else if (key == "orientation") {
+            iss >> cam.ox >> cam.oy >> cam.oz >> cam.oang;
+        } else if (key == "near") {
+            iss >> cam.znear;
+        } else if (key == "far") {
+            iss >> cam.zfar;
+        } else if (key == "left") {
+            iss >> cam.left;
+        } else if (key == "right") {
+            iss >> cam.right;
+        } else if (key == "top") {
+            iss >> cam.top;
+        } else if (key == "bottom") {
+            iss >> cam.bottom;
+        }
+    }
+
+    if (cam.znear == 0 || cam.zfar == cam.znear ||
+        cam.right == cam.left || cam.top == cam.bottom) {
+        throw std::runtime_error("Invalid frustum parameters");
+    }
+}
+
+Camera make_cam_matrices(const CameraParams& cam) {
+    Matrix4d T_C = make_translation(cam.px, cam.py, cam.pz);
+    Matrix4d R_C = make_rotation(cam.ox, cam.oy, cam.oz, cam.oang);
+    Matrix4d C_inv = (T_C * R_C).inverse();
+
+    double n = cam.znear;
+    double f = cam.zfar;
+    double l = cam.left;
+    double r = cam.right;
+    double b = cam.bottom;
+    double t = cam.top;
+
+    Matrix4d P;
+    P <<
+        (2 * n) / (r - l),  0,                  (r + l) / (r - l),   0,
+        0,                  (2 * n) / (t - b),  (t + b) / (t - b),   0,
+        0,                  0,                  -(f + n) / (f - n),  -(2 * f * n) / (f - n),
+        0,                  0,                  -1,                  0;
+
+    return Camera{C_inv, P};
+}
+
+} // namespace
+
+std::string parse_parent_path(const std::string& path) {
+    std::size_t pos = path.find_last_of("/\\");
+    if (pos == std::string::npos) return "";
+    return path.substr(0, pos);
+}
+
+std::size_t parse_size_t(const char* str) {
+    return static_cast<std::size_t>(std::stoul(str));
+}
+
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path) {
+    CameraParams cam;
+    std::vector<std::string> object_section_lines;
+
+    std::string raw;
+    bool in_camera = false;
+
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+        if (line == "camera:") { in_camera = true; break; }
+    }
+    if (!in_camera) {
+        throw std::runtime_error("Missing 'camera:' section");
+    }
+
+    std::vector<Light> lights;
+    read_cam_params_and_lights(cam, lights, fin);
+
+    while (std::getline(fin, raw)) {
+        object_section_lines.push_back(raw);
+    }
+
+    std::vector<std::string> object_names;
+    std::vector<std::string> object_paths;
+    std::size_t next_idx = parse_object_mappings(object_section_lines, object_names, object_paths);
+    std::vector<Object> objects = load_objects(object_paths, parent_path);
+
+    std::unordered_map<std::string, std::size_t> name_to_idx;
+    name_to_idx.reserve(object_names.size());
+    for (std::size_t i = 0; i < object_names.size(); ++i) {
+        name_to_idx.emplace(object_names[i], i);
+    }
+
+    std::vector<ObjectInstance> transformed_objects;
+    process_transform_blocks(object_section_lines, next_idx, objects,
+        object_names, name_to_idx, transformed_objects);
+
+    return Scene{make_cam_matrices(cam), std::move(transformed_objects), std::move(lights)};
+}
+

--- a/hw3/scene_loader.h
+++ b/hw3/scene_loader.h
@@ -1,0 +1,15 @@
+#ifndef HW3_SCENE_LOADER_H
+#define HW3_SCENE_LOADER_H
+
+#include "scene_types.h"
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <vector>
+
+std::string parse_parent_path(const std::string& path);
+std::size_t parse_size_t(const char* str);
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path);
+
+#endif

--- a/hw3/scene_types.h
+++ b/hw3/scene_types.h
@@ -1,0 +1,62 @@
+#ifndef HW3_SCENE_TYPES_H
+#define HW3_SCENE_TYPES_H
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <Eigen/Dense>
+
+struct Vertex {
+    double x, y, z;
+};
+
+struct Normal {
+    double x, y, z;
+};
+
+struct Face {
+    unsigned int v1, v2, v3;
+    unsigned int vn1, vn2, vn3;
+};
+
+struct Object {
+    std::string filename;
+    std::vector<Vertex> vertices;
+    std::vector<Normal> normals;
+    std::vector<Face> faces;
+};
+
+struct ObjectInstance {
+    Object obj;
+    std::string name;
+    Eigen::Vector3d ambient;
+    Eigen::Vector3d diffuse;
+    Eigen::Vector3d specular;
+    double shininess;
+};
+
+struct Light {
+    double x, y, z;
+    double r, g, b;
+    double atten;
+};
+
+struct CameraParams {
+    double px = 0, py = 0, pz = 0;
+    double ox = 0, oy = 1, oz = 0, oang = 0;
+    double znear = 0, zfar = 0;
+    double left = 0, right = 0, top = 0, bottom = 0;
+};
+
+struct Camera {
+    Eigen::Matrix4d Cinv;
+    Eigen::Matrix4d P;
+};
+
+struct Scene {
+    Camera cam_transforms;
+    std::vector<ObjectInstance> scene_objects;
+    std::vector<Light> lights;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- replace the hw3 build to produce an OpenGL-based opengl_renderer target
- port the assignment 2 scene loader so scenes can be parsed directly into OpenGL drawables
- add a quaternion-powered Arcball UI to rotate the rendered scene in the GLUT window

## Testing
- cmake -S . -B build -G "Ninja" *(fails: missing OpenGL development libraries in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fd234b6a44832289742d66864d3cc2