### PR TITLE
Add hw4 shader-based renderers for Phong shading and normal mapping

### DIFF
--- a/hw4/CMakeLists.txt
+++ b/hw4/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.24)
+project(hw4 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(OpenGL_GL_PREFERENCE GLVND)
+find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+find_package(GLUT REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(PNG REQUIRED)
+
+add_executable(opengl_renderer
+    opengl_renderer.cpp
+    scene_loader.cpp
+    texture_loader.cpp)
+
+target_include_directories(opengl_renderer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/Eigen)
+
+target_link_libraries(opengl_renderer PRIVATE GLUT::GLUT GLEW::GLEW OpenGL::GL PNG::PNG)

--- a/hw4/arcball.h
+++ b/hw4/arcball.h
@@ -1,0 +1,80 @@
+#ifndef HW3_ARCBALL_H
+#define HW3_ARCBALL_H
+
+#include "quaternion.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+class Arcball {
+public:
+    void set_window(int width, int height) {
+        window_width_ = std::max(width, 1);
+        window_height_ = std::max(height, 1);
+    }
+
+    void set_viewport(int vx, int vy, int vw, int vh) {
+        viewport_x_ = vx;
+        viewport_y_ = vy;
+        viewport_width_ = std::max(vw, 1);
+        viewport_height_ = std::max(vh, 1);
+    }
+
+    void begin_drag(int x, int y) {
+        dragging_ = true;
+        start_vec_ = map_to_sphere(x, y);
+        base_rotation_ = current_rotation_;
+    }
+
+    void update_drag(int x, int y) {
+        if (!dragging_) return;
+        auto current_vec = map_to_sphere(x, y);
+        Quaternion delta = Quaternion::from_unit_vectors(start_vec_, current_vec);
+        current_rotation_ = delta * base_rotation_;
+    }
+
+    void end_drag() {
+        dragging_ = false;
+    }
+
+    Quaternion rotation() const { return current_rotation_; }
+
+private:
+    std::array<double,3> map_to_sphere(int x, int y) const {
+        if (viewport_width_ <= 0 || viewport_height_ <= 0) {
+            return {0.0, 0.0, 1.0};
+        }
+
+        // Translate the mouse position into viewport space and normalize to [-1, 1]
+        double vx = static_cast<double>(x - viewport_x_);
+        double vy = static_cast<double>(viewport_height_ - (y - viewport_y_));
+        double nx = (2.0 * vx - viewport_width_) / viewport_width_;
+        double ny = (2.0 * vy - viewport_height_) / viewport_height_;
+
+        double length = nx * nx + ny * ny;
+        double nz;
+        if (length > 1.0) {
+            double norm = std::sqrt(length);
+            nx /= norm;
+            ny /= norm;
+            nz = 0.0;
+        } else {
+            nz = std::sqrt(1.0 - length);
+        }
+        return {nx, ny, nz};
+    }
+
+    int window_width_{1};
+    int window_height_{1};
+    int viewport_x_{0};
+    int viewport_y_{0};
+    int viewport_width_{1};
+    int viewport_height_{1};
+    bool dragging_{false};
+    std::array<double,3> start_vec_{0.0, 0.0, 1.0};
+    Quaternion base_rotation_ = Quaternion::identity();
+    Quaternion current_rotation_ = Quaternion::identity();
+};
+
+#endif

--- a/hw4/opengl_renderer.cpp
+++ b/hw4/opengl_renderer.cpp
@@ -1,0 +1,956 @@
+#include "arcball.h"
+#include "scene_loader.h"
+#include "texture_loader.h"
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
+#include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kMaxLights = 8;
+constexpr float kPi = 3.14159265358979323846f;
+
+enum class ProgramMode {
+    Scene,
+    NormalMapped
+};
+
+struct DrawableObject {
+    GLuint vbo_positions{0};
+    GLuint vbo_normals{0};
+    GLsizei vertex_count{0};
+    Eigen::Vector3f ambient{0.0f, 0.0f, 0.0f};
+    Eigen::Vector3f diffuse{0.0f, 0.0f, 0.0f};
+    Eigen::Vector3f specular{0.0f, 0.0f, 0.0f};
+    float shininess{1.0f};
+};
+
+struct SceneRenderer {
+    Scene scene;
+    std::vector<DrawableObject> drawables;
+    Arcball arcball;
+    ProgramMode mode{ProgramMode::Scene};
+    int shading_mode{0};
+
+    int window_width{800};
+    int window_height{800};
+
+    GLuint shader_program{0};
+    GLint attr_position{-1};
+    GLint attr_normal{-1};
+
+    GLint uniform_model_view{-1};
+    GLint uniform_projection{-1};
+    GLint uniform_normal_matrix{-1};
+    GLint uniform_light_count{-1};
+    GLint uniform_light_positions{-1};
+    GLint uniform_light_colors{-1};
+    GLint uniform_light_atten{-1};
+    GLint uniform_material_ambient{-1};
+    GLint uniform_material_diffuse{-1};
+    GLint uniform_material_specular{-1};
+    GLint uniform_material_shininess{-1};
+    GLint uniform_ambient_light{-1};
+    GLint uniform_shading_mode{-1};
+};
+
+struct QuadRenderer {
+    Arcball arcball;
+    int window_width{800};
+    int window_height{800};
+
+    GLuint shader_program{0};
+    GLuint vbo{0};
+    GLuint ibo{0};
+    GLuint color_texture{0};
+    GLuint normal_texture{0};
+
+    GLint attr_position{-1};
+    GLint attr_normal{-1};
+    GLint attr_tangent{-1};
+    GLint attr_bitangent{-1};
+    GLint attr_texcoord{-1};
+
+    GLint uniform_model_view{-1};
+    GLint uniform_projection{-1};
+    GLint uniform_normal_matrix{-1};
+    GLint uniform_color_tex{-1};
+    GLint uniform_normal_tex{-1};
+    GLint uniform_light_pos{-1};
+    GLint uniform_light_color{-1};
+    GLint uniform_ambient_light{-1};
+    GLint uniform_material_specular{-1};
+    GLint uniform_material_shininess{-1};
+
+    Eigen::Matrix4f view = Eigen::Matrix4f::Identity();
+    Eigen::Matrix4f projection = Eigen::Matrix4f::Identity();
+};
+
+ProgramMode g_program_mode = ProgramMode::Scene;
+SceneRenderer g_scene_renderer;
+QuadRenderer g_quad_renderer;
+std::string g_color_texture_path;
+std::string g_normal_texture_path;
+
+// Utility helpers -----------------------------------------------------------
+
+GLuint compile_shader(GLenum type, const char* source) {
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+
+    GLint success = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+    if (success != GL_TRUE) {
+        GLint log_length = 0;
+        glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_length);
+        std::vector<char> log(log_length + 1, '\0');
+        glGetShaderInfoLog(shader, log_length, nullptr, log.data());
+        std::string message = (type == GL_VERTEX_SHADER ? "Vertex" : "Fragment");
+        message += " shader compilation failed:\n";
+        message += log.data();
+        throw std::runtime_error(message);
+    }
+    return shader;
+}
+
+GLuint link_program(GLuint vertex_shader, GLuint fragment_shader,
+                    const std::vector<std::pair<GLuint, const char*>>& attributes = {}) {
+    GLuint program = glCreateProgram();
+    glAttachShader(program, vertex_shader);
+    glAttachShader(program, fragment_shader);
+
+    for (const auto& attr : attributes) {
+        glBindAttribLocation(program, attr.first, attr.second);
+    }
+
+    glLinkProgram(program);
+    GLint success = GL_FALSE;
+    glGetProgramiv(program, GL_LINK_STATUS, &success);
+    if (success != GL_TRUE) {
+        GLint log_length = 0;
+        glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_length);
+        std::vector<char> log(log_length + 1, '\0');
+        glGetProgramInfoLog(program, log_length, nullptr, log.data());
+        std::string message = "Program link failed:\n";
+        message += log.data();
+        throw std::runtime_error(message);
+    }
+    return program;
+}
+
+Eigen::Matrix4f to_matrix4f(const Eigen::Matrix4d& m) {
+    return m.cast<float>();
+}
+
+Eigen::Matrix3f normal_matrix_from(const Eigen::Matrix4f& model_view) {
+    Eigen::Matrix3f upper = model_view.block<3,3>(0,0);
+    return upper.inverse().transpose();
+}
+
+Eigen::Matrix4f matrix_from_arcball(const Arcball& arcball) {
+    auto arr = arcball.rotation().to_matrix();
+    Eigen::Matrix4f mat = Eigen::Matrix4f::Identity();
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            mat(row, col) = static_cast<float>(arr[col * 4 + row]);
+        }
+    }
+    return mat;
+}
+
+Eigen::Matrix4f perspective(float fovy_radians, float aspect, float znear, float zfar) {
+    float f = 1.0f / std::tan(fovy_radians * 0.5f);
+    Eigen::Matrix4f m = Eigen::Matrix4f::Zero();
+    m(0, 0) = f / aspect;
+    m(1, 1) = f;
+    m(2, 2) = (zfar + znear) / (znear - zfar);
+    m(2, 3) = (2.0f * zfar * znear) / (znear - zfar);
+    m(3, 2) = -1.0f;
+    return m;
+}
+
+Eigen::Matrix4f look_at(const Eigen::Vector3f& eye,
+                        const Eigen::Vector3f& center,
+                        const Eigen::Vector3f& up) {
+    Eigen::Vector3f f = (center - eye).normalized();
+    Eigen::Vector3f s = f.cross(up).normalized();
+    Eigen::Vector3f u = s.cross(f);
+
+    Eigen::Matrix4f m = Eigen::Matrix4f::Identity();
+    m.block<1,3>(0,0) = s.transpose();
+    m.block<1,3>(1,0) = u.transpose();
+    m.block<1,3>(2,0) = (-f).transpose();
+
+    Eigen::Matrix4f translate = Eigen::Matrix4f::Identity();
+    translate(0, 3) = -eye.x();
+    translate(1, 3) = -eye.y();
+    translate(2, 3) = -eye.z();
+
+    return m * translate;
+}
+
+float camera_aspect_from_P(const Eigen::Matrix4d& P) {
+    return static_cast<float>(P(1,1) / P(0,0));
+}
+
+struct Viewport {
+    int x{0};
+    int y{0};
+    int width{1};
+    int height{1};
+};
+
+Viewport apply_letterboxed_viewport(SceneRenderer& renderer, int win_w, int win_h) {
+    const float cam_aspect = camera_aspect_from_P(renderer.scene.cam_transforms.P);
+    const float window_aspect = static_cast<float>(win_w) / std::max(win_h, 1);
+
+    Viewport vp;
+    vp.width = win_w;
+    vp.height = win_h;
+    if (window_aspect > cam_aspect) {
+        vp.height = win_h;
+        vp.width = static_cast<int>(std::round(vp.height * cam_aspect));
+        vp.x = (win_w - vp.width) / 2;
+        vp.y = 0;
+    } else if (window_aspect < cam_aspect) {
+        vp.width = win_w;
+        vp.height = static_cast<int>(std::round(vp.width / cam_aspect));
+        vp.x = 0;
+        vp.y = (win_h - vp.height) / 2;
+    }
+    glViewport(vp.x, vp.y, std::max(vp.width,1), std::max(vp.height,1));
+    renderer.arcball.set_viewport(vp.x, vp.y, std::max(vp.width,1), std::max(vp.height,1));
+    return vp;
+}
+
+// Scene renderer ------------------------------------------------------------
+
+const char* kSceneVertexShader = R"GLSL(
+#version 120
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+
+uniform mat4 uModelView;
+uniform mat4 uProjection;
+uniform mat3 uNormalMatrix;
+uniform int uShadingMode;
+
+const int MAX_LIGHTS = 8;
+uniform int uLightCount;
+uniform vec3 uLightPosition[MAX_LIGHTS];
+uniform vec3 uLightColor[MAX_LIGHTS];
+uniform float uLightAtten[MAX_LIGHTS];
+
+uniform vec3 uMaterialAmbient;
+uniform vec3 uMaterialDiffuse;
+uniform vec3 uMaterialSpecular;
+uniform float uMaterialShininess;
+uniform vec3 uAmbientLight;
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+varying vec3 vVertexColor;
+
+vec3 applyLighting(vec3 position, vec3 normal) {
+    vec3 viewDir = normalize(-position);
+    vec3 color = uMaterialAmbient * uAmbientLight;
+    for (int i = 0; i < MAX_LIGHTS; ++i) {
+        if (i >= uLightCount) break;
+        vec3 lightVec = uLightPosition[i] - position;
+        float dist = length(lightVec);
+        if (dist > 0.0) {
+            lightVec /= dist;
+        }
+        float atten = 1.0 / (1.0 + uLightAtten[i] * dist * dist);
+        float diff = max(dot(normal, lightVec), 0.0);
+        vec3 reflectDir = reflect(-lightVec, normal);
+        float spec = 0.0;
+        if (diff > 0.0) {
+            spec = pow(max(dot(viewDir, reflectDir), 0.0), max(uMaterialShininess, 0.0));
+        }
+        vec3 lightColor = uLightColor[i];
+        color += atten * lightColor * (uMaterialDiffuse * diff + uMaterialSpecular * spec);
+    }
+    return clamp(color, 0.0, 1.0);
+}
+
+void main() {
+    vec4 viewPos = uModelView * vec4(aPosition, 1.0);
+    vec3 normal = normalize(uNormalMatrix * aNormal);
+    vPosition = viewPos.xyz;
+    vNormal = normal;
+    if (uShadingMode == 0) {
+        vVertexColor = applyLighting(viewPos.xyz, normal);
+    } else {
+        vVertexColor = vec3(0.0);
+    }
+    gl_Position = uProjection * viewPos;
+}
+)GLSL";
+
+const char* kSceneFragmentShader = R"GLSL(
+#version 120
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+varying vec3 vVertexColor;
+
+const int MAX_LIGHTS = 8;
+uniform int uLightCount;
+uniform vec3 uLightPosition[MAX_LIGHTS];
+uniform vec3 uLightColor[MAX_LIGHTS];
+uniform float uLightAtten[MAX_LIGHTS];
+
+uniform vec3 uMaterialAmbient;
+uniform vec3 uMaterialDiffuse;
+uniform vec3 uMaterialSpecular;
+uniform float uMaterialShininess;
+uniform vec3 uAmbientLight;
+uniform int uShadingMode;
+
+vec3 applyLighting(vec3 position, vec3 normal) {
+    vec3 viewDir = normalize(-position);
+    vec3 color = uMaterialAmbient * uAmbientLight;
+    for (int i = 0; i < MAX_LIGHTS; ++i) {
+        if (i >= uLightCount) break;
+        vec3 lightVec = uLightPosition[i] - position;
+        float dist = length(lightVec);
+        if (dist > 0.0) {
+            lightVec /= dist;
+        }
+        float atten = 1.0 / (1.0 + uLightAtten[i] * dist * dist);
+        float diff = max(dot(normal, lightVec), 0.0);
+        vec3 reflectDir = reflect(-lightVec, normal);
+        float spec = 0.0;
+        if (diff > 0.0) {
+            spec = pow(max(dot(viewDir, reflectDir), 0.0), max(uMaterialShininess, 0.0));
+        }
+        vec3 lightColor = uLightColor[i];
+        color += atten * lightColor * (uMaterialDiffuse * diff + uMaterialSpecular * spec);
+    }
+    return clamp(color, 0.0, 1.0);
+}
+
+void main() {
+    vec3 normal = normalize(vNormal);
+    vec3 color = vVertexColor;
+    if (uShadingMode != 0) {
+        color = applyLighting(vPosition, normal);
+    }
+    gl_FragColor = vec4(color, 1.0);
+}
+)GLSL";
+
+void destroy_scene_drawables(SceneRenderer& renderer) {
+    for (auto& drawable : renderer.drawables) {
+        if (drawable.vbo_positions) {
+            glDeleteBuffers(1, &drawable.vbo_positions);
+            drawable.vbo_positions = 0;
+        }
+        if (drawable.vbo_normals) {
+            glDeleteBuffers(1, &drawable.vbo_normals);
+            drawable.vbo_normals = 0;
+        }
+    }
+    renderer.drawables.clear();
+}
+
+void build_scene_drawables(SceneRenderer& renderer) {
+    destroy_scene_drawables(renderer);
+    renderer.drawables.reserve(renderer.scene.scene_objects.size());
+
+    for (const auto& inst : renderer.scene.scene_objects) {
+        DrawableObject drawable;
+        std::vector<GLfloat> positions;
+        std::vector<GLfloat> normals;
+        positions.reserve(inst.obj.faces.size() * 9);
+        normals.reserve(inst.obj.faces.size() * 9);
+
+        auto fill_material = [](const Eigen::Vector3d& src) {
+            return Eigen::Vector3f(static_cast<float>(src[0]),
+                                   static_cast<float>(src[1]),
+                                   static_cast<float>(src[2]));
+        };
+        drawable.ambient = fill_material(inst.ambient);
+        drawable.diffuse = fill_material(inst.diffuse);
+        drawable.specular = fill_material(inst.specular);
+        drawable.shininess = static_cast<float>(std::clamp(inst.shininess, 0.0, 128.0));
+
+        for (const auto& face : inst.obj.faces) {
+            const Vertex& v1 = inst.obj.vertices[face.v1];
+            const Vertex& v2 = inst.obj.vertices[face.v2];
+            const Vertex& v3 = inst.obj.vertices[face.v3];
+            const Normal& n1 = inst.obj.normals[face.vn1];
+            const Normal& n2 = inst.obj.normals[face.vn2];
+            const Normal& n3 = inst.obj.normals[face.vn3];
+
+            const std::array<const Vertex*, 3> verts{&v1, &v2, &v3};
+            const std::array<const Normal*, 3> norms{&n1, &n2, &n3};
+            for (int i = 0; i < 3; ++i) {
+                positions.push_back(static_cast<GLfloat>(verts[i]->x));
+                positions.push_back(static_cast<GLfloat>(verts[i]->y));
+                positions.push_back(static_cast<GLfloat>(verts[i]->z));
+
+                normals.push_back(static_cast<GLfloat>(norms[i]->x));
+                normals.push_back(static_cast<GLfloat>(norms[i]->y));
+                normals.push_back(static_cast<GLfloat>(norms[i]->z));
+            }
+        }
+
+        drawable.vertex_count = static_cast<GLsizei>(positions.size() / 3);
+        glGenBuffers(1, &drawable.vbo_positions);
+        glBindBuffer(GL_ARRAY_BUFFER, drawable.vbo_positions);
+        glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(GLfloat), positions.data(), GL_STATIC_DRAW);
+
+        glGenBuffers(1, &drawable.vbo_normals);
+        glBindBuffer(GL_ARRAY_BUFFER, drawable.vbo_normals);
+        glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(GLfloat), normals.data(), GL_STATIC_DRAW);
+
+        renderer.drawables.push_back(std::move(drawable));
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void init_scene_shader(SceneRenderer& renderer) {
+    GLuint vs = compile_shader(GL_VERTEX_SHADER, kSceneVertexShader);
+    GLuint fs = compile_shader(GL_FRAGMENT_SHADER, kSceneFragmentShader);
+
+    renderer.shader_program = link_program(vs, fs, {
+        {0, "aPosition"},
+        {1, "aNormal"}
+    });
+
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    renderer.attr_position = 0;
+    renderer.attr_normal = 1;
+
+    renderer.uniform_model_view = glGetUniformLocation(renderer.shader_program, "uModelView");
+    renderer.uniform_projection = glGetUniformLocation(renderer.shader_program, "uProjection");
+    renderer.uniform_normal_matrix = glGetUniformLocation(renderer.shader_program, "uNormalMatrix");
+    renderer.uniform_light_count = glGetUniformLocation(renderer.shader_program, "uLightCount");
+    renderer.uniform_light_positions = glGetUniformLocation(renderer.shader_program, "uLightPosition");
+    renderer.uniform_light_colors = glGetUniformLocation(renderer.shader_program, "uLightColor");
+    renderer.uniform_light_atten = glGetUniformLocation(renderer.shader_program, "uLightAtten");
+    renderer.uniform_material_ambient = glGetUniformLocation(renderer.shader_program, "uMaterialAmbient");
+    renderer.uniform_material_diffuse = glGetUniformLocation(renderer.shader_program, "uMaterialDiffuse");
+    renderer.uniform_material_specular = glGetUniformLocation(renderer.shader_program, "uMaterialSpecular");
+    renderer.uniform_material_shininess = glGetUniformLocation(renderer.shader_program, "uMaterialShininess");
+    renderer.uniform_ambient_light = glGetUniformLocation(renderer.shader_program, "uAmbientLight");
+    renderer.uniform_shading_mode = glGetUniformLocation(renderer.shader_program, "uShadingMode");
+}
+
+void init_scene_renderer(SceneRenderer& renderer) {
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+
+    init_scene_shader(renderer);
+    build_scene_drawables(renderer);
+}
+
+void render_scene(SceneRenderer& renderer) {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glUseProgram(renderer.shader_program);
+
+    Eigen::Matrix4f view = to_matrix4f(renderer.scene.cam_transforms.Cinv);
+    Eigen::Matrix4f projection = to_matrix4f(renderer.scene.cam_transforms.P);
+    Eigen::Matrix4f model = matrix_from_arcball(renderer.arcball);
+    Eigen::Matrix4f model_view = view * model;
+    Eigen::Matrix3f normal_matrix = normal_matrix_from(model_view);
+
+    glUniformMatrix4fv(renderer.uniform_model_view, 1, GL_FALSE, model_view.data());
+    glUniformMatrix4fv(renderer.uniform_projection, 1, GL_FALSE, projection.data());
+    glUniformMatrix3fv(renderer.uniform_normal_matrix, 1, GL_FALSE, normal_matrix.data());
+    glUniform1i(renderer.uniform_shading_mode, renderer.shading_mode);
+
+    const int light_count = std::min<int>(renderer.scene.lights.size(), kMaxLights);
+    std::vector<Eigen::Vector3f> light_positions(light_count);
+    std::vector<Eigen::Vector3f> light_colors(light_count);
+    std::vector<float> light_atten(light_count);
+
+    for (int i = 0; i < light_count; ++i) {
+        const auto& light = renderer.scene.lights[i];
+        Eigen::Vector4f pos(static_cast<float>(light.x),
+                            static_cast<float>(light.y),
+                            static_cast<float>(light.z),
+                            1.0f);
+        pos = model * pos; // rotate with the arcball
+        pos = view * pos;
+        light_positions[i] = pos.head<3>();
+        light_colors[i] = Eigen::Vector3f(static_cast<float>(light.r),
+                                          static_cast<float>(light.g),
+                                          static_cast<float>(light.b));
+        light_atten[i] = static_cast<float>(light.atten);
+    }
+
+    glUniform1i(renderer.uniform_light_count, light_count);
+    if (light_count > 0) {
+        glUniform3fv(renderer.uniform_light_positions, light_count, light_positions[0].data());
+        glUniform3fv(renderer.uniform_light_colors, light_count, light_colors[0].data());
+        glUniform1fv(renderer.uniform_light_atten, light_count, light_atten.data());
+    }
+
+    Eigen::Vector3f ambient_light(1.0f, 1.0f, 1.0f);
+    glUniform3fv(renderer.uniform_ambient_light, 1, ambient_light.data());
+
+    for (const auto& drawable : renderer.drawables) {
+        glUniform3fv(renderer.uniform_material_ambient, 1, drawable.ambient.data());
+        glUniform3fv(renderer.uniform_material_diffuse, 1, drawable.diffuse.data());
+        glUniform3fv(renderer.uniform_material_specular, 1, drawable.specular.data());
+        glUniform1f(renderer.uniform_material_shininess, drawable.shininess);
+
+        glBindBuffer(GL_ARRAY_BUFFER, drawable.vbo_positions);
+        glEnableVertexAttribArray(renderer.attr_position);
+        glVertexAttribPointer(renderer.attr_position, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+        glBindBuffer(GL_ARRAY_BUFFER, drawable.vbo_normals);
+        glEnableVertexAttribArray(renderer.attr_normal);
+        glVertexAttribPointer(renderer.attr_normal, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+        glDrawArrays(GL_TRIANGLES, 0, drawable.vertex_count);
+
+        glDisableVertexAttribArray(renderer.attr_position);
+        glDisableVertexAttribArray(renderer.attr_normal);
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glUseProgram(0);
+
+    glutSwapBuffers();
+}
+
+// Normal mapped quad -------------------------------------------------------
+
+const char* kQuadVertexShader = R"GLSL(
+#version 120
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec3 aTangent;
+attribute vec3 aBitangent;
+attribute vec2 aTexCoord;
+
+uniform mat4 uModelView;
+uniform mat4 uProjection;
+uniform mat3 uNormalMatrix;
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+varying vec3 vTangent;
+varying vec3 vBitangent;
+varying vec2 vTexCoord;
+
+void main() {
+    vec4 viewPos = uModelView * vec4(aPosition, 1.0);
+    vPosition = viewPos.xyz;
+    vNormal = normalize(uNormalMatrix * aNormal);
+    vTangent = normalize(uNormalMatrix * aTangent);
+    vBitangent = normalize(uNormalMatrix * aBitangent);
+    vTexCoord = aTexCoord;
+    gl_Position = uProjection * viewPos;
+}
+)GLSL";
+
+const char* kQuadFragmentShader = R"GLSL(
+#version 120
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+varying vec3 vTangent;
+varying vec3 vBitangent;
+varying vec2 vTexCoord;
+
+uniform sampler2D uColorTex;
+uniform sampler2D uNormalTex;
+uniform vec3 uLightPos;
+uniform vec3 uLightColor;
+uniform vec3 uAmbientLight;
+uniform vec3 uMaterialSpecular;
+uniform float uMaterialShininess;
+
+vec3 applyLighting(vec3 position, vec3 normal, vec3 baseColor) {
+    vec3 viewDir = normalize(-position);
+    vec3 lightVec = uLightPos - position;
+    float dist = length(lightVec);
+    if (dist > 0.0) {
+        lightVec /= dist;
+    }
+    float diff = max(dot(normal, lightVec), 0.0);
+    vec3 reflectDir = reflect(-lightVec, normal);
+    float spec = 0.0;
+    if (diff > 0.0) {
+        spec = pow(max(dot(viewDir, reflectDir), 0.0), max(uMaterialShininess, 0.0));
+    }
+
+    vec3 color = baseColor * uAmbientLight;
+    color += baseColor * diff * uLightColor;
+    color += uMaterialSpecular * spec * uLightColor;
+    return clamp(color, 0.0, 1.0);
+}
+
+void main() {
+    vec3 tangent = normalize(vTangent);
+    vec3 bitangent = normalize(vBitangent);
+    vec3 normal = normalize(vNormal);
+    mat3 TBN = mat3(tangent, bitangent, normal);
+
+    vec3 sampledNormal = texture2D(uNormalTex, vTexCoord).rgb;
+    sampledNormal = normalize(sampledNormal * 2.0 - 1.0);
+    vec3 worldNormal = normalize(TBN * sampledNormal);
+
+    vec3 baseColor = texture2D(uColorTex, vTexCoord).rgb;
+    vec3 color = applyLighting(vPosition, worldNormal, baseColor);
+    gl_FragColor = vec4(color, 1.0);
+}
+)GLSL";
+
+void destroy_quad_buffers(QuadRenderer& renderer) {
+    if (renderer.vbo) {
+        glDeleteBuffers(1, &renderer.vbo);
+        renderer.vbo = 0;
+    }
+    if (renderer.ibo) {
+        glDeleteBuffers(1, &renderer.ibo);
+        renderer.ibo = 0;
+    }
+    if (renderer.color_texture) {
+        glDeleteTextures(1, &renderer.color_texture);
+        renderer.color_texture = 0;
+    }
+    if (renderer.normal_texture) {
+        glDeleteTextures(1, &renderer.normal_texture);
+        renderer.normal_texture = 0;
+    }
+}
+
+void init_quad_renderer(QuadRenderer& renderer) {
+    GLuint vs = compile_shader(GL_VERTEX_SHADER, kQuadVertexShader);
+    GLuint fs = compile_shader(GL_FRAGMENT_SHADER, kQuadFragmentShader);
+    renderer.shader_program = link_program(vs, fs, {
+        {0, "aPosition"},
+        {1, "aNormal"},
+        {2, "aTangent"},
+        {3, "aBitangent"},
+        {4, "aTexCoord"}
+    });
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    renderer.attr_position = 0;
+    renderer.attr_normal = 1;
+    renderer.attr_tangent = 2;
+    renderer.attr_bitangent = 3;
+    renderer.attr_texcoord = 4;
+
+    renderer.uniform_model_view = glGetUniformLocation(renderer.shader_program, "uModelView");
+    renderer.uniform_projection = glGetUniformLocation(renderer.shader_program, "uProjection");
+    renderer.uniform_normal_matrix = glGetUniformLocation(renderer.shader_program, "uNormalMatrix");
+    renderer.uniform_color_tex = glGetUniformLocation(renderer.shader_program, "uColorTex");
+    renderer.uniform_normal_tex = glGetUniformLocation(renderer.shader_program, "uNormalTex");
+    renderer.uniform_light_pos = glGetUniformLocation(renderer.shader_program, "uLightPos");
+    renderer.uniform_light_color = glGetUniformLocation(renderer.shader_program, "uLightColor");
+    renderer.uniform_ambient_light = glGetUniformLocation(renderer.shader_program, "uAmbientLight");
+    renderer.uniform_material_specular = glGetUniformLocation(renderer.shader_program, "uMaterialSpecular");
+    renderer.uniform_material_shininess = glGetUniformLocation(renderer.shader_program, "uMaterialShininess");
+
+    struct Vertex {
+        GLfloat position[3];
+        GLfloat normal[3];
+        GLfloat tangent[3];
+        GLfloat bitangent[3];
+        GLfloat texcoord[2];
+    };
+
+    const std::array<Vertex, 4> vertices = {{{
+        {-1.0f, -1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f}
+    },{
+        {1.0f, -1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}
+    },{
+        {1.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 1.0f}
+    },{
+        {-1.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 1.0f}
+    }}};
+
+    const std::array<GLushort, 6> indices = {0, 1, 2, 0, 2, 3};
+
+    glGenBuffers(1, &renderer.vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, renderer.vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices.data(), GL_STATIC_DRAW);
+
+    glGenBuffers(1, &renderer.ibo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer.ibo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices.data(), GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+    renderer.color_texture = load_png_texture(g_color_texture_path);
+    renderer.normal_texture = load_png_texture(g_normal_texture_path);
+
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
+
+    renderer.view = look_at({0.0f, 0.0f, 4.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
+    renderer.projection = perspective(kPi / 4.0f, 1.0f, 0.1f, 100.0f);
+}
+
+void render_quad(QuadRenderer& renderer) {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glUseProgram(renderer.shader_program);
+
+    Eigen::Matrix4f model = matrix_from_arcball(renderer.arcball);
+    Eigen::Matrix4f model_view = renderer.view * model;
+    Eigen::Matrix3f normal_matrix = normal_matrix_from(model_view);
+
+    glUniformMatrix4fv(renderer.uniform_model_view, 1, GL_FALSE, model_view.data());
+    glUniformMatrix4fv(renderer.uniform_projection, 1, GL_FALSE, renderer.projection.data());
+    glUniformMatrix3fv(renderer.uniform_normal_matrix, 1, GL_FALSE, normal_matrix.data());
+
+    Eigen::Vector3f light_pos = (renderer.view * Eigen::Vector4f(0.0f, 0.0f, 4.0f, 1.0f)).head<3>();
+    Eigen::Vector3f light_color(1.0f, 1.0f, 1.0f);
+    Eigen::Vector3f ambient(0.2f, 0.2f, 0.2f);
+    Eigen::Vector3f specular(0.4f, 0.4f, 0.4f);
+    float shininess = 32.0f;
+
+    glUniform3fv(renderer.uniform_light_pos, 1, light_pos.data());
+    glUniform3fv(renderer.uniform_light_color, 1, light_color.data());
+    glUniform3fv(renderer.uniform_ambient_light, 1, ambient.data());
+    glUniform3fv(renderer.uniform_material_specular, 1, specular.data());
+    glUniform1f(renderer.uniform_material_shininess, shininess);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, renderer.color_texture);
+    glUniform1i(renderer.uniform_color_tex, 0);
+
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, renderer.normal_texture);
+    glUniform1i(renderer.uniform_normal_tex, 1);
+
+    glBindBuffer(GL_ARRAY_BUFFER, renderer.vbo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, renderer.ibo);
+
+    const GLsizei stride = sizeof(float) * (3 + 3 + 3 + 3 + 2);
+    std::size_t offset = 0;
+    glEnableVertexAttribArray(renderer.attr_position);
+    glVertexAttribPointer(renderer.attr_position, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<const void*>(offset));
+
+    offset += sizeof(float) * 3;
+    glEnableVertexAttribArray(renderer.attr_normal);
+    glVertexAttribPointer(renderer.attr_normal, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<const void*>(offset));
+
+    offset += sizeof(float) * 3;
+    glEnableVertexAttribArray(renderer.attr_tangent);
+    glVertexAttribPointer(renderer.attr_tangent, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<const void*>(offset));
+
+    offset += sizeof(float) * 3;
+    glEnableVertexAttribArray(renderer.attr_bitangent);
+    glVertexAttribPointer(renderer.attr_bitangent, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<const void*>(offset));
+
+    offset += sizeof(float) * 3;
+    glEnableVertexAttribArray(renderer.attr_texcoord);
+    glVertexAttribPointer(renderer.attr_texcoord, 2, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<const void*>(offset));
+
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, nullptr);
+
+    glDisableVertexAttribArray(renderer.attr_position);
+    glDisableVertexAttribArray(renderer.attr_normal);
+    glDisableVertexAttribArray(renderer.attr_tangent);
+    glDisableVertexAttribArray(renderer.attr_bitangent);
+    glDisableVertexAttribArray(renderer.attr_texcoord);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glUseProgram(0);
+
+    glutSwapBuffers();
+}
+
+// GLUT callbacks ------------------------------------------------------------
+
+void display_callback() {
+    if (g_program_mode == ProgramMode::Scene) {
+        render_scene(g_scene_renderer);
+    } else {
+        render_quad(g_quad_renderer);
+    }
+}
+
+void reshape_callback(int width, int height) {
+    if (width <= 0) width = 1;
+    if (height <= 0) height = 1;
+
+    if (g_program_mode == ProgramMode::Scene) {
+        g_scene_renderer.window_width = width;
+        g_scene_renderer.window_height = height;
+        g_scene_renderer.arcball.set_window(width, height);
+        auto vp = apply_letterboxed_viewport(g_scene_renderer, width, height);
+        (void)vp;
+    } else {
+        g_quad_renderer.window_width = width;
+        g_quad_renderer.window_height = height;
+        g_quad_renderer.arcball.set_window(width, height);
+        g_quad_renderer.arcball.set_viewport(0, 0, width, height);
+        glViewport(0, 0, width, height);
+        float aspect = static_cast<float>(width) / static_cast<float>(height);
+        g_quad_renderer.projection = perspective(kPi / 4.0f, aspect, 0.1f, 100.0f);
+    }
+    glutPostRedisplay();
+}
+
+void mouse_callback(int button, int state, int x, int y) {
+    if (button != GLUT_LEFT_BUTTON) return;
+    if (state == GLUT_DOWN) {
+        if (g_program_mode == ProgramMode::Scene) {
+            g_scene_renderer.arcball.begin_drag(x, y);
+        } else {
+            g_quad_renderer.arcball.begin_drag(x, y);
+        }
+    } else if (state == GLUT_UP) {
+        if (g_program_mode == ProgramMode::Scene) {
+            g_scene_renderer.arcball.end_drag();
+        } else {
+            g_quad_renderer.arcball.end_drag();
+        }
+    }
+    glutPostRedisplay();
+}
+
+void motion_callback(int x, int y) {
+    if (g_program_mode == ProgramMode::Scene) {
+        g_scene_renderer.arcball.update_drag(x, y);
+    } else {
+        g_quad_renderer.arcball.update_drag(x, y);
+    }
+    glutPostRedisplay();
+}
+
+void keyboard_callback(unsigned char key, int, int) {
+    if (key == 27 || key == 'q' || key == 'Q') {
+        destroy_scene_drawables(g_scene_renderer);
+        destroy_quad_buffers(g_quad_renderer);
+        std::exit(0);
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 5) {
+        g_program_mode = ProgramMode::Scene;
+    } else if (argc == 3) {
+        g_program_mode = ProgramMode::NormalMapped;
+    } else {
+        std::cerr << "Usage (scene): " << argv[0] << " [scene.txt] [xres] [yres] [mode]\n";
+        std::cerr << "Usage (normal map): " << argv[0] << " [color_texture.png] [normal_map.png]\n";
+        return 1;
+    }
+
+    glutInit(&argc, argv);
+    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+
+    if (g_program_mode == ProgramMode::Scene) {
+        const std::size_t xres = parse_size_t(argv[2]);
+        const std::size_t yres = parse_size_t(argv[3]);
+        int mode = 0;
+        try {
+            mode = std::stoi(argv[4]);
+        } catch (const std::exception&) {
+            std::cerr << "Mode must be an integer (0 for Gouraud, 1 for Phong)\n";
+            return 1;
+        }
+        if (mode != 0 && mode != 1) {
+            std::cerr << "Mode must be 0 (Gouraud) or 1 (Phong)\n";
+            return 1;
+        }
+
+        std::ifstream fin(argv[1]);
+        if (!fin) {
+            std::cerr << "Could not open scene file: " << argv[1] << "\n";
+            return 1;
+        }
+
+        try {
+            g_scene_renderer.scene = parse_scene_file(fin, parse_parent_path(argv[1]));
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to parse scene: " << e.what() << "\n";
+            return 1;
+        }
+
+        g_scene_renderer.shading_mode = mode;
+        g_scene_renderer.window_width = static_cast<int>(xres);
+        g_scene_renderer.window_height = static_cast<int>(yres);
+        g_scene_renderer.arcball.set_window(g_scene_renderer.window_width, g_scene_renderer.window_height);
+
+        glutInitWindowSize(g_scene_renderer.window_width, g_scene_renderer.window_height);
+        glutInitWindowPosition(0, 0);
+        glutCreateWindow("OpenGL Scene Renderer");
+    } else {
+        g_color_texture_path = argv[1];
+        g_normal_texture_path = argv[2];
+
+        g_quad_renderer.window_width = 800;
+        g_quad_renderer.window_height = 800;
+        g_quad_renderer.arcball.set_window(g_quad_renderer.window_width, g_quad_renderer.window_height);
+
+        glutInitWindowSize(g_quad_renderer.window_width, g_quad_renderer.window_height);
+        glutInitWindowPosition(0, 0);
+        glutCreateWindow("Normal Mapped Quad");
+    }
+
+    GLenum err = glewInit();
+    if (err != GLEW_OK) {
+        std::cerr << "GLEW init error: " << glewGetErrorString(err) << "\n";
+        return 1;
+    }
+
+    try {
+        if (g_program_mode == ProgramMode::Scene) {
+            init_scene_renderer(g_scene_renderer);
+            apply_letterboxed_viewport(g_scene_renderer, g_scene_renderer.window_width, g_scene_renderer.window_height);
+        } else {
+            init_quad_renderer(g_quad_renderer);
+            reshape_callback(g_quad_renderer.window_width, g_quad_renderer.window_height);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Initialization error: " << e.what() << "\n";
+        return 1;
+    }
+
+    glutDisplayFunc(display_callback);
+    glutReshapeFunc(reshape_callback);
+    glutMouseFunc(mouse_callback);
+    glutMotionFunc(motion_callback);
+    glutKeyboardFunc(keyboard_callback);
+
+    glutMainLoop();
+    return 0;
+}

--- a/hw4/quaternion.h
+++ b/hw4/quaternion.h
@@ -1,0 +1,121 @@
+#ifndef HW3_QUATERNION_H
+#define HW3_QUATERNION_H
+
+#include <array>
+#include <cmath>
+
+struct Quaternion {
+    double w{1.0};
+    double x{0.0};
+    double y{0.0};
+    double z{0.0};
+
+    Quaternion() = default; // use base vals by default
+    Quaternion(double w_, double x_, double y_, double z_)
+        : w(w_), x(x_), y(y_), z(z_) {}
+
+    static Quaternion identity() { return Quaternion(); }
+
+    // standard formula from lecture notes
+    static Quaternion from_axis_angle(double axis_x, double axis_y, double axis_z, double angle) {
+        double half = angle * 0.5;
+        double s = std::sin(half);
+        return Quaternion(std::cos(half), axis_x * s, axis_y * s, axis_z * s);
+    } 
+
+    // Finds the shortest arc-rotation between two unit vectors
+    static Quaternion from_unit_vectors(const std::array<double,3>& from,
+                                        const std::array<double,3>& to) {
+        double dot = from[0]*to[0] + from[1]*to[1] + from[2]*to[2];
+        std::array<double,3> cross{
+            from[1]*to[2] - from[2]*to[1],
+            from[2]*to[0] - from[0]*to[2],
+            from[0]*to[1] - from[1]*to[0]
+        };
+        // Theorem: [1 + a dot b, a cross b] is proportional to [cos(theta/2), u sin(theta/2)]
+        // Where theta is the angle between the two vectors and u is the axis
+        Quaternion q(dot + 1.0, cross[0], cross[1], cross[2]);
+        if (q.length_squared() < 1e-12) {
+            // Vectors are nearly opposite, so choose arbitrary orthogonal axis
+            std::array<double,3> ortho;
+            if (std::abs(from[0]) > std::abs(from[1]))
+                ortho = { -from[2], 0.0, from[0] };
+            else
+                ortho = { 0.0, -from[2], from[1] };
+            return Quaternion(0.0, ortho[0], ortho[1], ortho[2]).normalized();
+        }
+        // Since our quaternion is proportional, we normalize to get a unique representation
+        return q.normalized();
+    }
+
+    Quaternion normalized() const {
+        double len = std::sqrt(length_squared());
+        if (len == 0.0) return Quaternion();
+        return Quaternion(w / len, x / len, y / len, z / len);
+    }
+
+    double length_squared() const {
+        return w*w + x*x + y*y + z*z;
+    }
+
+    // Simplified form of lecture notes multiplication
+    // This is calculated as [sa*sb - va dot vb, sa*vb + sb*va + va cross vb]
+    Quaternion operator*(const Quaternion& rhs) const {
+        return Quaternion(
+            w*rhs.w - x*rhs.x - y*rhs.y - z*rhs.z,
+            w*rhs.x + x*rhs.w + y*rhs.z - z*rhs.y,
+            w*rhs.y - x*rhs.z + y*rhs.w + z*rhs.x,
+            w*rhs.z + x*rhs.y - y*rhs.x + z*rhs.w
+        );
+    }
+
+    // Directly from hw3 lecture notes
+    std::array<double,16> to_matrix() const {
+        Quaternion n = normalized();
+        double xx = n.x * n.x;
+        double yy = n.y * n.y;
+        double zz = n.z * n.z;
+        double xy = n.x * n.y;
+        double xz = n.x * n.z;
+        double yz = n.y * n.z;
+        double wx = n.w * n.x;
+        double wy = n.w * n.y;
+        double wz = n.w * n.z;
+
+        // return {
+        //     1.0 - 2.0*(yy + zz), 2.0*(xy - wz),       2.0*(xz + wy),       0.0,
+        //     2.0*(xy + wz),       1.0 - 2.0*(xx + zz), 2.0*(yz - wx),       0.0,
+        //     2.0*(xz - wy),       2.0*(yz + wx),       1.0 - 2.0*(xx + yy), 0.0,
+        //     0.0,                 0.0,                 0.0,                 1.0
+        // };
+
+        // Return must be column major!
+        return {
+            // column 0
+            1.0 - 2.0*(yy + zz),
+            2.0*(xy + wz),
+            2.0*(xz - wy),
+            0.0,
+
+            // column 1
+            2.0*(xy - wz),
+            1.0 - 2.0*(xx + zz),
+            2.0*(yz + wx),
+            0.0,
+
+            // column 2
+            2.0*(xz + wy),
+            2.0*(yz - wx),
+            1.0 - 2.0*(xx + yy),
+            0.0,
+
+            // column 3
+            0.0, 
+            0.0, 
+            0.0, 
+            1.0
+        };
+    }
+};
+
+#endif

--- a/hw4/scene_loader.cpp
+++ b/hw4/scene_loader.cpp
@@ -1,0 +1,435 @@
+#include "scene_loader.h"
+
+#include <Eigen/Geometry>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Matrix4d;
+using Eigen::Vector3d;
+
+// Reused from hw2
+
+namespace {
+std::string join_path(const std::string& parent, const std::string& filename) {
+    if (parent.empty()) return filename;
+    if (parent.back() == '/' || parent.back() == '\\') return parent + filename;
+    return parent + "/" + filename;
+}
+
+Matrix4d make_translation(double tx, double ty, double tz) {
+    Matrix4d T = Matrix4d::Identity();
+    T(0, 3) = tx;
+    T(1, 3) = ty;
+    T(2, 3) = tz;
+    return T;
+}
+
+Matrix4d make_scaling(double sx, double sy, double sz) {
+    Matrix4d S = Matrix4d::Identity();
+    S(0, 0) = sx;
+    S(1, 1) = sy;
+    S(2, 2) = sz;
+    return S;
+}
+
+Matrix4d make_rotation(double rx, double ry, double rz, double angle) {
+    Vector3d axis(rx, ry, rz);
+    if (axis.norm() == 0.0) {
+        return Matrix4d::Identity();
+    }
+    axis.normalize();
+    Matrix3d R3 = AngleAxisd(angle, axis).toRotationMatrix();
+    Matrix4d R = Matrix4d::Identity();
+    R.block<3,3>(0,0) = R3;
+    return R;
+}
+
+void apply_transform_to_object(Object& src, const Matrix4d& M, bool transform_normals = true) {
+    for (std::size_t vi = 1; vi < src.vertices.size(); ++vi) {
+        auto& v = src.vertices[vi];
+        Eigen::Vector4d p(v.x, v.y, v.z, 1.0);
+        Eigen::Vector3d q = (M * p).hnormalized();
+        v.x = q[0];
+        v.y = q[1];
+        v.z = q[2];
+    }
+
+    if (transform_normals) {
+        const Matrix3d A = M.block<3,3>(0,0);
+        Matrix3d N;
+        double det = A.determinant();
+        if (std::abs(det) < 1e-15) {
+            N = Matrix3d::Identity();
+        } else {
+            N = A.inverse().transpose();
+        }
+
+        for (std::size_t ni = 1; ni < src.normals.size(); ++ni) {
+            auto& vn = src.normals[ni];
+            Eigen::Vector3d n(vn.x, vn.y, vn.z);
+            n = N * n;
+            n.normalize();
+            vn.x = n.x();
+            vn.y = n.y();
+            vn.z = n.z();
+        }
+    }
+}
+
+Matrix4d make_transform_from_lines(const std::vector<std::string>& lines) {
+    Matrix4d M = Matrix4d::Identity();
+    std::size_t lineno = 0;
+
+    for (const auto& raw_line : lines) {
+        ++lineno;
+        auto first_non_ws = raw_line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw_line[first_non_ws] == '#') continue;
+
+        std::istringstream iss(raw_line.substr(first_non_ws));
+        char kind;
+        iss >> kind;
+        if (!iss) continue;
+
+        Matrix4d T = Matrix4d::Identity();
+        if (kind == 't') {
+            double tx, ty, tz;
+            if (!(iss >> tx >> ty >> tz)) {
+                throw std::runtime_error("Invalid translation at line " + std::to_string(lineno));
+            }
+            T = make_translation(tx, ty, tz);
+        } else if (kind == 's') {
+            double sx, sy, sz;
+            if (!(iss >> sx >> sy >> sz)) {
+                throw std::runtime_error("Invalid scale at line " + std::to_string(lineno));
+            }
+            T = make_scaling(sx, sy, sz);
+        } else if (kind == 'r') {
+            double rx, ry, rz, angle;
+            if (!(iss >> rx >> ry >> rz >> angle)) {
+                throw std::runtime_error("Invalid rotation at line " + std::to_string(lineno));
+            }
+            T = make_rotation(rx, ry, rz, angle);
+        }
+
+        M = T * M;
+    }
+
+    return M;
+}
+
+std::size_t find_string_idx(
+    const std::string& name,
+    const std::unordered_map<std::string, std::size_t>& name_to_idx) {
+    auto it = name_to_idx.find(name);
+    if (it == name_to_idx.end()) {
+        throw std::out_of_range("Name not found: " + name);
+    }
+    return it->second;
+}
+
+std::vector<Object> load_objects(const std::vector<std::string>& fpaths,
+                                 const std::string& parent_path) {
+    std::vector<Object> objects;
+    for (const auto& filename : fpaths) {
+        std::string file_path = join_path(parent_path, filename);
+        std::ifstream file(file_path);
+        if (!file) {
+            throw std::runtime_error("Error: Could not open file " + file_path);
+        }
+
+        std::vector<Vertex> vertices{{0.0, 0.0, 0.0}};
+        std::vector<Normal> normals{{0.0, 0.0, 0.0}};
+        std::vector<Face> faces;
+        std::string line;
+
+        while (std::getline(file, line)) {
+            auto first_non_ws = line.find_first_not_of(" \t\r\n");
+            if (first_non_ws == std::string::npos) continue;
+            if (line[first_non_ws] == '#') continue;
+
+            std::istringstream line_stream(line.substr(first_non_ws));
+            std::string type;
+            line_stream >> type;
+
+            if (type == "v") {
+                double x, y, z;
+                if (!(line_stream >> x >> y >> z)) {
+                    throw std::runtime_error("Invalid vertex format");
+                }
+                vertices.push_back({x, y, z});
+            } else if (type == "vn") {
+                double x, y, z;
+                if (!(line_stream >> x >> y >> z)) {
+                    throw std::runtime_error("Invalid normal format");
+                }
+                normals.push_back({x, y, z});
+            } else if (type == "f") {
+                unsigned int v_idx[3], n_idx[3];
+                for (int i = 0; i < 3; ++i) {
+                    std::string token;
+                    if (!(line_stream >> token)) {
+                        throw std::runtime_error("Invalid face format");
+                    }
+                    auto pos = token.find("//");
+                    if (pos == std::string::npos) {
+                        throw std::runtime_error("Expected 'v//vn' format");
+                    }
+                    v_idx[i] = static_cast<unsigned int>(std::stoul(token.substr(0, pos)));
+                    n_idx[i] = static_cast<unsigned int>(std::stoul(token.substr(pos + 2)));
+                }
+                faces.push_back({v_idx[0], v_idx[1], v_idx[2], n_idx[0], n_idx[1], n_idx[2]});
+            }
+        }
+
+        objects.push_back({file_path, std::move(vertices), std::move(normals), std::move(faces)});
+    }
+
+    return objects;
+}
+
+std::size_t parse_object_mappings(const std::vector<std::string>& lines,
+                                  std::vector<std::string>& object_names,
+                                  std::vector<std::string>& object_paths) {
+    bool started_mapping = false;
+    std::size_t i = 0;
+
+    for (; i < lines.size(); ++i) {
+        const std::string& line = lines[i];
+        auto first_non_ws = line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            if (started_mapping) { ++i; break; }
+            continue;
+        }
+        if (line[first_non_ws] == '#') continue;
+
+        started_mapping = true;
+        std::istringstream iss(line.substr(first_non_ws));
+        std::string name, path;
+        if (!(iss >> name >> path)) {
+            throw std::runtime_error("Invalid object mapping: " + line);
+        }
+        object_names.push_back(name);
+        object_paths.push_back(path);
+    }
+
+    return i;
+}
+
+void process_transform_blocks(const std::vector<std::string>& lines,
+                              std::size_t start_idx,
+                              std::vector<Object>& objects,
+                              const std::vector<std::string>& object_names,
+                              const std::unordered_map<std::string, std::size_t>& name_to_idx,
+                              std::vector<ObjectInstance>& out_transformed) {
+    if (objects.size() != object_names.size()) {
+        throw std::runtime_error("Mismatched object counts");
+    }
+
+    std::unordered_map<std::string, std::size_t> copy_count;
+    std::string current_name;
+    std::vector<std::string> current_transform_lines;
+    Eigen::Vector3d current_ambient = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_diffuse = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_specular = Eigen::Vector3d::Zero();
+    double current_shininess = 0.0;
+
+    auto flush_instance = [&]() {
+        if (current_name.empty() || current_transform_lines.empty()) {
+            current_transform_lines.clear();
+            return;
+        }
+        std::size_t base_idx = find_string_idx(current_name, name_to_idx);
+        Matrix4d M = make_transform_from_lines(current_transform_lines);
+        auto base = objects.at(base_idx);
+        apply_transform_to_object(base, M);
+        std::size_t n = ++copy_count[current_name];
+        std::string out_name = current_name + "_copy" + std::to_string(n);
+        out_transformed.emplace_back(ObjectInstance{std::move(base), out_name,
+            current_ambient, current_diffuse, current_specular, current_shininess});
+        current_name.clear();
+        current_transform_lines.clear();
+        current_ambient.setZero();
+        current_diffuse.setZero();
+        current_specular.setZero();
+        current_shininess = 0.0;
+    };
+
+    for (std::size_t i = start_idx; i < lines.size(); ++i) {
+        const std::string& tline = lines[i];
+        auto first_non_ws = tline.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            flush_instance();
+            continue;
+        }
+        if (tline[first_non_ws] == '#') continue;
+
+        std::istringstream iss(tline.substr(first_non_ws));
+        std::string tok;
+        iss >> tok;
+        if (!iss && tok.empty()) continue;
+
+        if (tok == "ambient") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_ambient = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "diffuse") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_diffuse = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "specular") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_specular = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "shininess") {
+            if (current_name.empty()) continue;
+            double s = 0; iss >> s;
+            current_shininess = s;
+            continue;
+        }
+
+        if (tok == "t" || tok == "r" || tok == "s") {
+            if (current_name.empty()) continue;
+            current_transform_lines.push_back(tline.substr(first_non_ws));
+            continue;
+        }
+
+        flush_instance();
+        current_name = tok;
+    }
+
+    flush_instance();
+}
+
+void read_cam_params_and_lights(CameraParams& cam, std::vector<Light>& lights, std::ifstream& fin) {
+    std::string raw;
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+
+        if (line == "objects:") {
+            break;
+        }
+
+        std::istringstream iss(line);
+        std::string key; iss >> key;
+
+        if (key == "light") {
+            double x, y, z, r, g, b, atten;
+            char comma;
+            if (!(iss >> x >> y >> z >> comma >> r >> g >> b >> comma >> atten)) {
+                throw std::runtime_error("Invalid light format");
+            }
+            lights.push_back({x, y, z, r, g, b, atten});
+        } else if (key == "position") {
+            iss >> cam.px >> cam.py >> cam.pz;
+        } else if (key == "orientation") {
+            iss >> cam.ox >> cam.oy >> cam.oz >> cam.oang;
+        } else if (key == "near") {
+            iss >> cam.znear;
+        } else if (key == "far") {
+            iss >> cam.zfar;
+        } else if (key == "left") {
+            iss >> cam.left;
+        } else if (key == "right") {
+            iss >> cam.right;
+        } else if (key == "top") {
+            iss >> cam.top;
+        } else if (key == "bottom") {
+            iss >> cam.bottom;
+        }
+    }
+
+    if (cam.znear == 0 || cam.zfar == cam.znear ||
+        cam.right == cam.left || cam.top == cam.bottom) {
+        throw std::runtime_error("Invalid frustum parameters");
+    }
+}
+
+Camera make_cam_matrices(const CameraParams& cam) {
+    Matrix4d T_C = make_translation(cam.px, cam.py, cam.pz);
+    Matrix4d R_C = make_rotation(cam.ox, cam.oy, cam.oz, cam.oang);
+    Matrix4d C_inv = (T_C * R_C).inverse();
+
+    double n = cam.znear;
+    double f = cam.zfar;
+    double l = cam.left;
+    double r = cam.right;
+    double b = cam.bottom;
+    double t = cam.top;
+
+    Matrix4d P;
+    P <<
+        (2 * n) / (r - l),  0,                  (r + l) / (r - l),   0,
+        0,                  (2 * n) / (t - b),  (t + b) / (t - b),   0,
+        0,                  0,                  -(f + n) / (f - n),  -(2 * f * n) / (f - n),
+        0,                  0,                  -1,                  0;
+
+    return Camera{C_inv, P};
+}
+
+} // namespace
+
+std::string parse_parent_path(const std::string& path) {
+    std::size_t pos = path.find_last_of("/\\");
+    if (pos == std::string::npos) return "";
+    return path.substr(0, pos);
+}
+
+std::size_t parse_size_t(const char* str) {
+    return static_cast<std::size_t>(std::stoul(str));
+}
+
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path) {
+    CameraParams cam;
+    std::vector<std::string> object_section_lines;
+
+    std::string raw;
+    bool in_camera = false;
+
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+        if (line == "camera:") { in_camera = true; break; }
+    }
+    if (!in_camera) {
+        throw std::runtime_error("Missing 'camera:' section");
+    }
+
+    std::vector<Light> lights;
+    read_cam_params_and_lights(cam, lights, fin);
+
+    while (std::getline(fin, raw)) {
+        object_section_lines.push_back(raw);
+    }
+
+    std::vector<std::string> object_names;
+    std::vector<std::string> object_paths;
+    std::size_t next_idx = parse_object_mappings(object_section_lines, object_names, object_paths);
+    std::vector<Object> objects = load_objects(object_paths, parent_path);
+
+    std::unordered_map<std::string, std::size_t> name_to_idx;
+    name_to_idx.reserve(object_names.size());
+    for (std::size_t i = 0; i < object_names.size(); ++i) {
+        name_to_idx.emplace(object_names[i], i);
+    }
+
+    std::vector<ObjectInstance> transformed_objects;
+    process_transform_blocks(object_section_lines, next_idx, objects,
+        object_names, name_to_idx, transformed_objects);
+
+    return Scene{make_cam_matrices(cam), std::move(transformed_objects), std::move(lights)};
+}
+

--- a/hw4/scene_loader.h
+++ b/hw4/scene_loader.h
@@ -1,0 +1,17 @@
+#ifndef HW3_SCENE_LOADER_H
+#define HW3_SCENE_LOADER_H
+
+#include "scene_types.h"
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// Reused from hw2
+
+std::string parse_parent_path(const std::string& path);
+std::size_t parse_size_t(const char* str);
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path);
+
+#endif

--- a/hw4/scene_types.h
+++ b/hw4/scene_types.h
@@ -1,0 +1,64 @@
+#ifndef HW3_SCENE_TYPES_H
+#define HW3_SCENE_TYPES_H
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <Eigen/Dense>
+
+// Reused from hw2
+
+struct Vertex {
+    double x, y, z;
+};
+
+struct Normal {
+    double x, y, z;
+};
+
+struct Face {
+    unsigned int v1, v2, v3;
+    unsigned int vn1, vn2, vn3;
+};
+
+struct Object {
+    std::string filename;
+    std::vector<Vertex> vertices;
+    std::vector<Normal> normals;
+    std::vector<Face> faces;
+};
+
+struct ObjectInstance {
+    Object obj;
+    std::string name;
+    Eigen::Vector3d ambient;
+    Eigen::Vector3d diffuse;
+    Eigen::Vector3d specular;
+    double shininess;
+};
+
+struct Light {
+    double x, y, z;
+    double r, g, b;
+    double atten;
+};
+
+struct CameraParams {
+    double px = 0, py = 0, pz = 0;
+    double ox = 0, oy = 1, oz = 0, oang = 0;
+    double znear = 0, zfar = 0;
+    double left = 0, right = 0, top = 0, bottom = 0;
+};
+
+struct Camera {
+    Eigen::Matrix4d Cinv;
+    Eigen::Matrix4d P;
+};
+
+struct Scene {
+    Camera cam_transforms;
+    std::vector<ObjectInstance> scene_objects;
+    std::vector<Light> lights;
+};
+
+#endif

--- a/hw4/texture_loader.cpp
+++ b/hw4/texture_loader.cpp
@@ -1,0 +1,129 @@
+#include "texture_loader.h"
+
+#include <png.h>
+
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+struct PngReadGuard {
+    png_structp png_ptr{nullptr};
+    png_infop info_ptr{nullptr};
+    png_infop end_info{nullptr};
+    FILE* file{nullptr};
+
+    ~PngReadGuard() {
+        if (png_ptr || info_ptr || end_info) {
+            png_destroy_read_struct(png_ptr ? &png_ptr : nullptr,
+                                    info_ptr ? &info_ptr : nullptr,
+                                    end_info ? &end_info : nullptr);
+        }
+        if (file) {
+            std::fclose(file);
+        }
+    }
+};
+}
+
+GLuint load_png_texture(const std::string& filename) {
+    PngReadGuard guard;
+    guard.file = std::fopen(filename.c_str(), "rb");
+    if (!guard.file) {
+        throw std::runtime_error("Failed to open PNG file: " + filename);
+    }
+
+    png_byte header[8];
+    if (std::fread(header, 1, sizeof(header), guard.file) != sizeof(header)) {
+        throw std::runtime_error("Failed to read PNG header: " + filename);
+    }
+    if (png_sig_cmp(header, 0, sizeof(header)) != 0) {
+        throw std::runtime_error("File is not a valid PNG image: " + filename);
+    }
+
+    guard.png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!guard.png_ptr) {
+        throw std::runtime_error("png_create_read_struct failed for: " + filename);
+    }
+
+    guard.info_ptr = png_create_info_struct(guard.png_ptr);
+    guard.end_info = png_create_info_struct(guard.png_ptr);
+    if (!guard.info_ptr || !guard.end_info) {
+        throw std::runtime_error("png_create_info_struct failed for: " + filename);
+    }
+
+    if (setjmp(png_jmpbuf(guard.png_ptr))) {
+        throw std::runtime_error("libpng error while reading: " + filename);
+    }
+
+    png_init_io(guard.png_ptr, guard.file);
+    png_set_sig_bytes(guard.png_ptr, sizeof(header));
+    png_read_info(guard.png_ptr, guard.info_ptr);
+
+    png_uint_32 width = 0;
+    png_uint_32 height = 0;
+    int bit_depth = 0;
+    int color_type = 0;
+    png_get_IHDR(guard.png_ptr, guard.info_ptr, &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
+
+    if (bit_depth == 16) {
+        png_set_strip_16(guard.png_ptr);
+    }
+    if (color_type == PNG_COLOR_TYPE_PALETTE) {
+        png_set_palette_to_rgb(guard.png_ptr);
+    }
+    if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
+        png_set_expand_gray_1_2_4_to_8(guard.png_ptr);
+    }
+    if (png_get_valid(guard.png_ptr, guard.info_ptr, PNG_INFO_tRNS)) {
+        png_set_tRNS_to_alpha(guard.png_ptr);
+    }
+    if (color_type == PNG_COLOR_TYPE_RGB || color_type == PNG_COLOR_TYPE_GRAY ||
+        color_type == PNG_COLOR_TYPE_PALETTE) {
+        png_set_filler(guard.png_ptr, 0xFF, PNG_FILLER_AFTER);
+    }
+    if (color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_GRAY_ALPHA) {
+        png_set_gray_to_rgb(guard.png_ptr);
+    }
+
+    png_read_update_info(guard.png_ptr, guard.info_ptr);
+
+    png_size_t rowbytes = png_get_rowbytes(guard.png_ptr, guard.info_ptr);
+    std::vector<png_byte> image_data(rowbytes * height);
+    std::vector<png_bytep> row_pointers(height);
+    for (png_uint_32 y = 0; y < height; ++y) {
+        row_pointers[y] = image_data.data() + y * rowbytes;
+    }
+
+    png_read_image(guard.png_ptr, row_pointers.data());
+    png_read_end(guard.png_ptr, guard.end_info);
+
+    // Flip the image vertically so textures appear right-side up
+    std::vector<png_byte> flipped(rowbytes * height);
+    for (png_uint_32 y = 0; y < height; ++y) {
+        std::memcpy(flipped.data() + (height - 1 - y) * rowbytes,
+                    image_data.data() + y * rowbytes,
+                    rowbytes);
+    }
+
+    GLuint texture = 0;
+    glGenTextures(1, &texture);
+    if (texture == 0) {
+        throw std::runtime_error("glGenTextures failed while loading: " + filename);
+    }
+
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(width), static_cast<GLsizei>(height), 0,
+                 GL_RGBA, GL_UNSIGNED_BYTE, flipped.data());
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return texture;
+}

--- a/hw4/texture_loader.h
+++ b/hw4/texture_loader.h
@@ -1,0 +1,9 @@
+#ifndef HW4_TEXTURE_LOADER_H
+#define HW4_TEXTURE_LOADER_H
+
+#include <string>
+#include <GL/glew.h>
+
+GLuint load_png_texture(const std::string& filename);
+
+#endif


### PR DESCRIPTION
## Summary
- port the hw3 scene loader and arcball controls into hw4 with a shader-based OpenGL renderer
- implement Gouraud and per-pixel Phong shading modes selectable via the CLI mode argument
- add a textured normal-mapped quad renderer that supports arcball rotation and PNG textures

## Testing
- `cmake -S hw4 -B hw4/build` *(fails: missing OpenGL development libraries in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d6f63e94c83228b7825331303a750)