### PR TITLE
Add implicit fairing renderer for hw5

### DIFF
--- a/hw5/CMakeLists.txt
+++ b/hw5/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.24)
+project(hw5 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14) # C++ 14 for Eigen compatibility, required
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(OpenGL REQUIRED)
+find_package(GLUT REQUIRED)
+find_package(GLEW REQUIRED)
+
+add_executable(smooth
+    smooth.cpp
+    scene_loader.cpp)
+
+target_include_directories(smooth PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(smooth PRIVATE GLUT::GLUT GLEW::GLEW OpenGL::GL)

--- a/hw5/README.md
+++ b/hw5/README.md
@@ -1,0 +1,19 @@
+# HW5 Implicit Fairing
+
+This program renders a mesh scene and applies implicit fairing to smooth the geometry. Run with:
+
+```
+./smooth [scene_description_file.txt] [xres] [yres] [h]
+```
+
+Press **`f`** to run the implicit fairing step using the provided time step `h`. Press **`q`** or **Esc** to quit.
+
+## Building the fairing operator
+
+For each vertex with mixed area \(A\), the discrete cotangent Laplacian uses
+
+\[
+(\Delta x)_i = \frac{1}{2A} \sum_j (\cot \alpha_{ij} + \cot \beta_{ij})(x_j - x_i),
+\]
+
+where \(\alpha_{ij}\) and \(\beta_{ij}\) are the angles opposite the edge \((i, j)\) in the two incident triangles. The implicit system uses \(F = I - h\Delta\), so off-diagonal entries become \(-h\, w/(2A)\) and the diagonal accumulates \(1 + h\,\sum w /(2A)\), matching the construction in `smooth.cpp`.

--- a/hw5/arcball.h
+++ b/hw5/arcball.h
@@ -1,0 +1,64 @@
+#ifndef HW3_ARCBALL_H
+#define HW3_ARCBALL_H
+
+#include "quaternion.h"
+
+#include <array>
+#include <cmath>
+
+class Arcball {
+public:
+    void set_window(int width, int height) {
+        window_width_ = width;
+        window_height_ = height;
+    }
+
+    void begin_drag(int x, int y) {
+        dragging_ = true;
+        start_vec_ = map_to_sphere(x, y);
+        base_rotation_ = current_rotation_;
+    }
+
+    void update_drag(int x, int y) {
+        if (!dragging_) return;
+        auto current_vec = map_to_sphere(x, y);
+        Quaternion delta = Quaternion::from_unit_vectors(start_vec_, current_vec);
+        current_rotation_ = delta * base_rotation_;
+    }
+
+    void end_drag() {
+        dragging_ = false;
+    }
+
+    Quaternion rotation() const { return current_rotation_; }
+
+private:
+    std::array<double,3> map_to_sphere(int x, int y) const {
+        if (window_width_ == 0 || window_height_ == 0) {
+            return {0.0, 0.0, 1.0};
+        }
+        // Get x and y deviations from center, normalized to be in [-1, 1] (NDC)
+        double nx = (2.0 * x - window_width_) / window_width_;
+        double ny = (window_height_ - 2.0 * y) / window_height_; // Flip y since mouseY = 0 is top
+        double length = nx*nx + ny*ny;
+        double nz;
+        if (length > 1.0) {
+            double norm = std::sqrt(length);
+            nx /= norm;
+            ny /= norm;
+            nz = 0.0; // Rotate across z axis when out of bounds
+        } else {
+            nz = std::sqrt(1.0 - length); // Since xx+yy+zz=1 is on the unit sphere
+        }
+        return {nx, ny, nz};
+    }
+
+    int window_width_{1};
+    int window_height_{1};
+    bool dragging_{false};
+    std::array<double,3> start_vec_{0.0, 0.0, 1.0};
+    Quaternion base_rotation_ = Quaternion::identity();
+    Quaternion current_rotation_ = Quaternion::identity();
+};
+
+#endif

--- a/hw5/quaternion.h
+++ b/hw5/quaternion.h
@@ -1,0 +1,121 @@
+#ifndef HW3_QUATERNION_H
+#define HW3_QUATERNION_H
+
+#include <array>
+#include <cmath>
+
+struct Quaternion {
+    double w{1.0};
+    double x{0.0};
+    double y{0.0};
+    double z{0.0};
+
+    Quaternion() = default; // use base vals by default
+    Quaternion(double w_, double x_, double y_, double z_)
+        : w(w_), x(x_), y(y_), z(z_) {}
+
+    static Quaternion identity() { return Quaternion(); }
+
+    // standard formula from lecture notes
+    static Quaternion from_axis_angle(double axis_x, double axis_y, double axis_z, double angle) {
+        double half = angle * 0.5;
+        double s = std::sin(half);
+        return Quaternion(std::cos(half), axis_x * s, axis_y * s, axis_z * s);
+    } 
+
+    // Finds the shortest arc-rotation between two unit vectors
+    static Quaternion from_unit_vectors(const std::array<double,3>& from,
+                                        const std::array<double,3>& to) {
+        double dot = from[0]*to[0] + from[1]*to[1] + from[2]*to[2];
+        std::array<double,3> cross{
+            from[1]*to[2] - from[2]*to[1],
+            from[2]*to[0] - from[0]*to[2],
+            from[0]*to[1] - from[1]*to[0]
+        };
+        // Theorem: [1 + a dot b, a cross b] is proportional to [cos(theta/2), u sin(theta/2)]
+        // Where theta is the angle between the two vectors and u is the axis
+        Quaternion q(dot + 1.0, cross[0], cross[1], cross[2]);
+        if (q.length_squared() < 1e-12) {
+            // Vectors are nearly opposite, so choose arbitrary orthogonal axis
+            std::array<double,3> ortho;
+            if (std::abs(from[0]) > std::abs(from[1]))
+                ortho = { -from[2], 0.0, from[0] };
+            else
+                ortho = { 0.0, -from[2], from[1] };
+            return Quaternion(0.0, ortho[0], ortho[1], ortho[2]).normalized();
+        }
+        // Since our quaternion is proportional, we normalize to get a unique representation
+        return q.normalized();
+    }
+
+    Quaternion normalized() const {
+        double len = std::sqrt(length_squared());
+        if (len == 0.0) return Quaternion();
+        return Quaternion(w / len, x / len, y / len, z / len);
+    }
+
+    double length_squared() const {
+        return w*w + x*x + y*y + z*z;
+    }
+
+    // Simplified form of lecture notes multiplication
+    // This is calculated as [sa*sb - va dot vb, sa*vb + sb*va + va cross vb]
+    Quaternion operator*(const Quaternion& rhs) const {
+        return Quaternion(
+            w*rhs.w - x*rhs.x - y*rhs.y - z*rhs.z,
+            w*rhs.x + x*rhs.w + y*rhs.z - z*rhs.y,
+            w*rhs.y - x*rhs.z + y*rhs.w + z*rhs.x,
+            w*rhs.z + x*rhs.y - y*rhs.x + z*rhs.w
+        );
+    }
+
+    // Directly from hw3 lecture notes
+    std::array<double,16> to_matrix() const {
+        Quaternion n = normalized();
+        double xx = n.x * n.x;
+        double yy = n.y * n.y;
+        double zz = n.z * n.z;
+        double xy = n.x * n.y;
+        double xz = n.x * n.z;
+        double yz = n.y * n.z;
+        double wx = n.w * n.x;
+        double wy = n.w * n.y;
+        double wz = n.w * n.z;
+
+        // return {
+        //     1.0 - 2.0*(yy + zz), 2.0*(xy - wz),       2.0*(xz + wy),       0.0,
+        //     2.0*(xy + wz),       1.0 - 2.0*(xx + zz), 2.0*(yz - wx),       0.0,
+        //     2.0*(xz - wy),       2.0*(yz + wx),       1.0 - 2.0*(xx + yy), 0.0,
+        //     0.0,                 0.0,                 0.0,                 1.0
+        // };
+
+        // Return must be column major!
+        return {
+            // column 0
+            1.0 - 2.0*(yy + zz),
+            2.0*(xy + wz),
+            2.0*(xz - wy),
+            0.0,
+
+            // column 1
+            2.0*(xy - wz),
+            1.0 - 2.0*(xx + zz),
+            2.0*(yz + wx),
+            0.0,
+
+            // column 2
+            2.0*(xz + wy),
+            2.0*(yz - wx),
+            1.0 - 2.0*(xx + yy),
+            0.0,
+
+            // column 3
+            0.0, 
+            0.0, 
+            0.0, 
+            1.0
+        };
+    }
+};
+
+#endif

--- a/hw5/scene_loader.cpp
+++ b/hw5/scene_loader.cpp
@@ -1,0 +1,399 @@
+#include "scene_loader.h"
+
+#include <Eigen/Geometry>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Matrix4d;
+using Eigen::Vector3d;
+
+namespace {
+
+std::string join_path(const std::string& parent, const std::string& filename) {
+    if (parent.empty()) return filename;
+    if (parent.back() == '/' || parent.back() == '\\') return parent + filename;
+    return parent + "/" + filename;
+}
+
+Matrix4d make_translation(double tx, double ty, double tz) {
+    Matrix4d T = Matrix4d::Identity();
+    T(0, 3) = tx;
+    T(1, 3) = ty;
+    T(2, 3) = tz;
+    return T;
+}
+
+Matrix4d make_scaling(double sx, double sy, double sz) {
+    Matrix4d S = Matrix4d::Identity();
+    S(0, 0) = sx;
+    S(1, 1) = sy;
+    S(2, 2) = sz;
+    return S;
+}
+
+Matrix4d make_rotation(double rx, double ry, double rz, double angle) {
+    Vector3d axis(rx, ry, rz);
+    if (axis.norm() == 0.0) {
+        return Matrix4d::Identity();
+    }
+    axis.normalize();
+    Matrix3d R3 = AngleAxisd(angle, axis).toRotationMatrix();
+    Matrix4d R = Matrix4d::Identity();
+    R.block<3,3>(0,0) = R3;
+    return R;
+}
+
+void apply_transform_to_object(Object& src, const Matrix4d& M) {
+    for (std::size_t vi = 1; vi < src.vertices.size(); ++vi) {
+        auto& v = src.vertices[vi];
+        Eigen::Vector4d p(v.x, v.y, v.z, 1.0);
+        Eigen::Vector3d q = (M * p).hnormalized();
+        v.x = q[0];
+        v.y = q[1];
+        v.z = q[2];
+    }
+}
+
+Matrix4d make_transform_from_lines(const std::vector<std::string>& lines) {
+    Matrix4d M = Matrix4d::Identity();
+    std::size_t lineno = 0;
+
+    for (const auto& raw_line : lines) {
+        ++lineno;
+        auto first_non_ws = raw_line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw_line[first_non_ws] == '#') continue;
+
+        std::istringstream iss(raw_line.substr(first_non_ws));
+        char kind;
+        iss >> kind;
+        if (!iss) continue;
+
+        Matrix4d T = Matrix4d::Identity();
+        if (kind == 't') {
+            double tx, ty, tz;
+            if (!(iss >> tx >> ty >> tz)) {
+                throw std::runtime_error("Invalid translation at line " + std::to_string(lineno));
+            }
+            T = make_translation(tx, ty, tz);
+        } else if (kind == 's') {
+            double sx, sy, sz;
+            if (!(iss >> sx >> sy >> sz)) {
+                throw std::runtime_error("Invalid scale at line " + std::to_string(lineno));
+            }
+            T = make_scaling(sx, sy, sz);
+        } else if (kind == 'r') {
+            double rx, ry, rz, angle;
+            if (!(iss >> rx >> ry >> rz >> angle)) {
+                throw std::runtime_error("Invalid rotation at line " + std::to_string(lineno));
+            }
+            T = make_rotation(rx, ry, rz, angle);
+        }
+
+        M = T * M;
+    }
+
+    return M;
+}
+
+std::size_t find_string_idx(
+    const std::string& name,
+    const std::unordered_map<std::string, std::size_t>& name_to_idx) {
+    auto it = name_to_idx.find(name);
+    if (it == name_to_idx.end()) {
+        throw std::out_of_range("Name not found: " + name);
+    }
+    return it->second;
+}
+
+std::vector<Object> load_objects(const std::vector<std::string>& fpaths,
+                                 const std::string& parent_path) {
+    std::vector<Object> objects;
+    for (const auto& filename : fpaths) {
+        std::string file_path = join_path(parent_path, filename);
+        std::ifstream file(file_path);
+        if (!file) {
+            throw std::runtime_error("Error: Could not open file " + file_path);
+        }
+
+        std::vector<Vertex> vertices{{0.0, 0.0, 0.0}};
+        std::vector<Face> faces;
+        std::string line;
+
+        while (std::getline(file, line)) {
+            auto first_non_ws = line.find_first_not_of(" \t\r\n");
+            if (first_non_ws == std::string::npos) continue;
+            if (line[first_non_ws] == '#') continue;
+
+            std::istringstream line_stream(line.substr(first_non_ws));
+            std::string type;
+            line_stream >> type;
+
+            if (type == "v") {
+                double x, y, z;
+                if (!(line_stream >> x >> y >> z)) {
+                    throw std::runtime_error("Invalid vertex format");
+                }
+                vertices.push_back({x, y, z});
+            } else if (type == "f") {
+                unsigned int v_idx[3];
+                for (int i = 0; i < 3; ++i) {
+                    if (!(line_stream >> v_idx[i])) {
+                        throw std::runtime_error("Invalid face format");
+                    }
+                }
+                faces.push_back({v_idx[0], v_idx[1], v_idx[2]});
+            }
+        }
+
+        objects.push_back({file_path, std::move(vertices), std::move(faces)});
+    }
+
+    return objects;
+}
+
+std::size_t parse_object_mappings(const std::vector<std::string>& lines,
+                                  std::vector<std::string>& object_names,
+                                  std::vector<std::string>& object_paths) {
+    bool started_mapping = false;
+    std::size_t i = 0;
+
+    for (; i < lines.size(); ++i) {
+        const std::string& line = lines[i];
+        auto first_non_ws = line.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            if (started_mapping) { ++i; break; }
+            continue;
+        }
+        if (line[first_non_ws] == '#') continue;
+
+        started_mapping = true;
+        std::istringstream iss(line.substr(first_non_ws));
+        std::string name, path;
+        if (!(iss >> name >> path)) {
+            throw std::runtime_error("Invalid object mapping: " + line);
+        }
+        object_names.push_back(name);
+        object_paths.push_back(path);
+    }
+
+    return i;
+}
+
+void process_transform_blocks(const std::vector<std::string>& lines,
+                              std::size_t start_idx,
+                              std::vector<Object>& objects,
+                              const std::vector<std::string>& object_names,
+                              const std::unordered_map<std::string, std::size_t>& name_to_idx,
+                              std::vector<ObjectInstance>& out_transformed) {
+    if (objects.size() != object_names.size()) {
+        throw std::runtime_error("Mismatched object counts");
+    }
+
+    std::unordered_map<std::string, std::size_t> copy_count;
+    std::string current_name;
+    std::vector<std::string> current_transform_lines;
+    Eigen::Vector3d current_ambient = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_diffuse = Eigen::Vector3d::Zero();
+    Eigen::Vector3d current_specular = Eigen::Vector3d::Zero();
+    double current_shininess = 0.0;
+
+    auto flush_instance = [&]() {
+        if (current_name.empty() || current_transform_lines.empty()) {
+            current_transform_lines.clear();
+            return;
+        }
+        std::size_t base_idx = find_string_idx(current_name, name_to_idx);
+        Matrix4d M = make_transform_from_lines(current_transform_lines);
+        auto base = objects.at(base_idx);
+        apply_transform_to_object(base, M);
+        std::size_t n = ++copy_count[current_name];
+        std::string out_name = current_name + "_copy" + std::to_string(n);
+        out_transformed.emplace_back(ObjectInstance{std::move(base), out_name,
+            current_ambient, current_diffuse, current_specular, current_shininess});
+        current_name.clear();
+        current_transform_lines.clear();
+        current_ambient.setZero();
+        current_diffuse.setZero();
+        current_specular.setZero();
+        current_shininess = 0.0;
+    };
+
+    for (std::size_t i = start_idx; i < lines.size(); ++i) {
+        const std::string& tline = lines[i];
+        auto first_non_ws = tline.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) {
+            flush_instance();
+            continue;
+        }
+        if (tline[first_non_ws] == '#') continue;
+
+        std::istringstream iss(tline.substr(first_non_ws));
+        std::string tok;
+        iss >> tok;
+        if (!iss && tok.empty()) continue;
+
+        if (tok == "ambient") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_ambient = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "diffuse") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_diffuse = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "specular") {
+            if (current_name.empty()) continue;
+            double x=0, y=0, z=0; iss >> x >> y >> z;
+            current_specular = Eigen::Vector3d(x, y, z);
+            continue;
+        } else if (tok == "shininess") {
+            if (current_name.empty()) continue;
+            double s = 0; iss >> s;
+            current_shininess = s;
+            continue;
+        }
+
+        if (tok == "t" || tok == "r" || tok == "s") {
+            if (current_name.empty()) continue;
+            current_transform_lines.push_back(tline.substr(first_non_ws));
+            continue;
+        }
+
+        flush_instance();
+        current_name = tok;
+    }
+
+    flush_instance();
+}
+
+void read_cam_params_and_lights(CameraParams& cam, std::vector<Light>& lights, std::ifstream& fin) {
+    std::string raw;
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+
+        if (line == "objects:") {
+            break;
+        }
+
+        std::istringstream iss(line);
+        std::string key; iss >> key;
+
+        if (key == "light") {
+            double x, y, z, r, g, b, atten;
+            char comma;
+            if (!(iss >> x >> y >> z >> comma >> r >> g >> b >> comma >> atten)) {
+                throw std::runtime_error("Invalid light format");
+            }
+            lights.push_back({x, y, z, r, g, b, atten});
+        } else if (key == "position") {
+            iss >> cam.px >> cam.py >> cam.pz;
+        } else if (key == "orientation") {
+            iss >> cam.ox >> cam.oy >> cam.oz >> cam.oang;
+        } else if (key == "near") {
+            iss >> cam.znear;
+        } else if (key == "far") {
+            iss >> cam.zfar;
+        } else if (key == "left") {
+            iss >> cam.left;
+        } else if (key == "right") {
+            iss >> cam.right;
+        } else if (key == "top") {
+            iss >> cam.top;
+        } else if (key == "bottom") {
+            iss >> cam.bottom;
+        }
+    }
+
+    if (cam.znear == 0 || cam.zfar == cam.znear ||
+        cam.right == cam.left || cam.top == cam.bottom) {
+        throw std::runtime_error("Invalid frustum parameters");
+    }
+}
+
+Camera make_cam_matrices(const CameraParams& cam) {
+    Matrix4d T_C = make_translation(cam.px, cam.py, cam.pz);
+    Matrix4d R_C = make_rotation(cam.ox, cam.oy, cam.oz, cam.oang);
+    Matrix4d C_inv = (T_C * R_C).inverse();
+
+    double n = cam.znear;
+    double f = cam.zfar;
+    double l = cam.left;
+    double r = cam.right;
+    double b = cam.bottom;
+    double t = cam.top;
+
+    Matrix4d P;
+    P <<
+        (2 * n) / (r - l),  0,                  (r + l) / (r - l),   0,
+        0,                  (2 * n) / (t - b),  (t + b) / (t - b),   0,
+        0,                  0,                  -(f + n) / (f - n),  -(2 * f * n) / (f - n),
+        0,                  0,                  -1,                  0;
+
+    return Camera{C_inv, P};
+}
+
+} // namespace
+
+std::string parse_parent_path(const std::string& path) {
+    std::size_t pos = path.find_last_of("/\\");
+    if (pos == std::string::npos) return "";
+    return path.substr(0, pos);
+}
+
+std::size_t parse_size_t(const char* str) {
+    return static_cast<std::size_t>(std::stoul(str));
+}
+
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path) {
+    CameraParams cam;
+    std::vector<std::string> object_section_lines;
+
+    std::string raw;
+    bool in_camera = false;
+
+    while (std::getline(fin, raw)) {
+        auto first_non_ws = raw.find_first_not_of(" \t\r\n");
+        if (first_non_ws == std::string::npos) continue;
+        if (raw[first_non_ws] == '#') continue;
+        std::string line = raw.substr(first_non_ws);
+        if (line == "camera:") { in_camera = true; break; }
+    }
+    if (!in_camera) {
+        throw std::runtime_error("Missing 'camera:' section");
+    }
+
+    std::vector<Light> lights;
+    read_cam_params_and_lights(cam, lights, fin);
+
+    while (std::getline(fin, raw)) {
+        object_section_lines.push_back(raw);
+    }
+
+    std::vector<std::string> object_names;
+    std::vector<std::string> object_paths;
+    std::size_t next_idx = parse_object_mappings(object_section_lines, object_names, object_paths);
+    std::vector<Object> objects = load_objects(object_paths, parent_path);
+
+    std::unordered_map<std::string, std::size_t> name_to_idx;
+    name_to_idx.reserve(object_names.size());
+    for (std::size_t i = 0; i < object_names.size(); ++i) {
+        name_to_idx.emplace(object_names[i], i);
+    }
+
+    std::vector<ObjectInstance> transformed_objects;
+    process_transform_blocks(object_section_lines, next_idx, objects,
+        object_names, name_to_idx, transformed_objects);
+
+    return Scene{make_cam_matrices(cam), std::move(transformed_objects), std::move(lights)};
+}
+

--- a/hw5/scene_loader.h
+++ b/hw5/scene_loader.h
@@ -1,0 +1,15 @@
+#ifndef HW5_SCENE_LOADER_H
+#define HW5_SCENE_LOADER_H
+
+#include "scene_types.h"
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <vector>
+
+std::string parse_parent_path(const std::string& path);
+std::size_t parse_size_t(const char* str);
+Scene parse_scene_file(std::ifstream& fin, const std::string& parent_path);
+
+#endif

--- a/hw5/scene_types.h
+++ b/hw5/scene_types.h
@@ -1,0 +1,58 @@
+#ifndef HW3_SCENE_TYPES_H
+#define HW3_SCENE_TYPES_H
+
+#include <Eigen/Dense>
+#include <string>
+#include <vector>
+
+// Reused from hw2/hw3 but simplified for meshes without normals
+
+struct Vertex {
+    double x, y, z;
+};
+
+struct Face {
+    unsigned int v1, v2, v3;
+};
+
+struct Object {
+    std::string filename;
+    // 1-indexed vertex list, vertices[0] is dummy to align with OBJ indices
+    std::vector<Vertex> vertices;
+    std::vector<Face> faces;
+};
+
+struct ObjectInstance {
+    Object obj;
+    std::string name;
+    Eigen::Vector3d ambient;
+    Eigen::Vector3d diffuse;
+    Eigen::Vector3d specular;
+    double shininess;
+};
+
+struct Light {
+    double x, y, z;
+    double r, g, b;
+    double atten;
+};
+
+struct CameraParams {
+    double px = 0, py = 0, pz = 0;
+    double ox = 0, oy = 1, oz = 0, oang = 0;
+    double znear = 0, zfar = 0;
+    double left = 0, right = 0, top = 0, bottom = 0;
+};
+
+struct Camera {
+    Eigen::Matrix4d Cinv;
+    Eigen::Matrix4d P;
+};
+
+struct Scene {
+    Camera cam_transforms;
+    std::vector<ObjectInstance> scene_objects;
+    std::vector<Light> lights;
+};
+
+#endif

--- a/hw5/smooth.cpp
+++ b/hw5/smooth.cpp
@@ -1,0 +1,551 @@
+#include "scene_loader.h"
+#include "arcball.h"
+#include "halfedge.h"
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
+#include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+struct MeshGeometry {
+    Object obj;
+    std::vector<Vertex*> vertex_ptrs;
+    std::vector<Face*> face_ptrs;
+    std::vector<HEV*> hevs;
+    std::vector<HEF*> hefs;
+    std::vector<Vec3f> vertex_normals; // 1-indexed to match vertex order
+};
+
+struct RenderObject {
+    MeshGeometry mesh;
+    GLfloat ambient[4];
+    GLfloat diffuse[4];
+    GLfloat specular[4];
+    GLfloat shininess;
+};
+
+struct DrawableObject {
+    std::vector<GLfloat> vertices;
+    std::vector<GLfloat> normals;
+    GLfloat ambient[4];
+    GLfloat diffuse[4];
+    GLfloat specular[4];
+    GLfloat shininess;
+};
+
+namespace {
+
+Scene g_scene;
+std::vector<RenderObject> g_render_objects;
+std::vector<DrawableObject> g_drawables;
+Arcball g_arcball;
+int g_window_width = 800;
+int g_window_height = 800;
+double g_time_step = 0.0;
+
+Eigen::Vector3d hev_pos(const HEV* v) {
+    return Eigen::Vector3d(v->x, v->y, v->z);
+}
+
+Vec3f calc_face_normal(const HEF* face) {
+    const HE* e0 = face->edge;
+    const HE* e1 = face->edge->next;
+    const HE* e2 = face->edge->next->next;
+
+    Eigen::Vector3d p0 = hev_pos(e0->vertex);
+    Eigen::Vector3d p1 = hev_pos(e1->vertex);
+    Eigen::Vector3d p2 = hev_pos(e2->vertex);
+
+    Eigen::Vector3d n = (p1 - p0).cross(p2 - p0);
+    if (n.norm() > 0.0) {
+        n.normalize();
+    }
+    return Vec3f{static_cast<float>(n.x()), static_cast<float>(n.y()), static_cast<float>(n.z())};
+}
+
+double calc_area(const HEF* face) {
+    const HE* e0 = face->edge;
+    const HE* e1 = face->edge->next;
+    const HE* e2 = face->edge->next->next;
+
+    Eigen::Vector3d p0 = hev_pos(e0->vertex);
+    Eigen::Vector3d p1 = hev_pos(e1->vertex);
+    Eigen::Vector3d p2 = hev_pos(e2->vertex);
+
+    return 0.5 * ((p1 - p0).cross(p2 - p0)).norm();
+}
+
+void compute_vertex_normals(MeshGeometry& mesh) {
+    mesh.vertex_normals.assign(mesh.hevs.size(), Vec3f{0.0f, 0.0f, 0.0f});
+
+    for (std::size_t i = 1; i < mesh.hevs.size(); ++i) {
+        HEV* v = mesh.hevs[i];
+        if (v->out == nullptr) continue;
+
+        Eigen::Vector3d accum = Eigen::Vector3d::Zero();
+        HE* he_start = v->out;
+        HE* he = he_start;
+        do {
+            Vec3f face_normal = calc_face_normal(he->face);
+            Eigen::Vector3d n(face_normal.x, face_normal.y, face_normal.z);
+            double area = calc_area(he->face);
+            accum += area * n;
+            he = he->flip->next;
+        } while (he != he_start);
+
+        if (accum.norm() > 0.0) {
+            accum.normalize();
+        }
+        v->normal = Vec3f{static_cast<float>(accum.x()), static_cast<float>(accum.y()), static_cast<float>(accum.z())};
+        mesh.vertex_normals[i] = v->normal;
+    }
+}
+
+double calc_cotangent(const HE* edge) {
+    const HEV* v0 = edge->vertex;
+    const HEV* v1 = edge->next->vertex;
+    const HEV* v2 = edge->next->next->vertex; // vertex opposite the edge
+
+    Eigen::Vector3d a = hev_pos(v0) - hev_pos(v2);
+    Eigen::Vector3d b = hev_pos(v1) - hev_pos(v2);
+    Eigen::Vector3d cross = a.cross(b);
+    double sin_theta = cross.norm();
+    if (sin_theta < 1e-12) return 0.0;
+    return a.dot(b) / sin_theta;
+}
+
+double vertex_mixed_area(const HEV* v) {
+    if (v->out == nullptr) return 0.0;
+    double area = 0.0;
+    HE* he_start = v->out;
+    HE* he = he_start;
+    do {
+        area += calc_area(he->face) / 3.0;
+        he = he->flip->next;
+    } while (he != he_start);
+    return area;
+}
+
+Eigen::SparseMatrix<double> build_fairing_matrix(const MeshGeometry& mesh, double h) {
+    const std::size_t n = mesh.hevs.size() - 1;
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve(n * 7); // heuristic
+
+    for (std::size_t i = 1; i < mesh.hevs.size(); ++i) {
+        HEV* v = mesh.hevs[i];
+        int row = v->index;
+        if (v->out == nullptr) {
+            triplets.emplace_back(row, row, 1.0);
+            continue;
+        }
+
+        double area = vertex_mixed_area(v);
+        if (std::abs(area) < 1e-12) {
+            triplets.emplace_back(row, row, 1.0);
+            continue;
+        }
+
+        double weight_sum = 0.0;
+        HE* he_start = v->out;
+        HE* he = he_start;
+        do {
+            HEV* neighbor = he->next->vertex;
+            double cot1 = calc_cotangent(he);
+            double cot2 = (he->flip != nullptr) ? calc_cotangent(he->flip) : 0.0;
+            double w = cot1 + cot2;
+            weight_sum += w;
+
+            // Using (I - h * Δ) with the cotangent Laplacian Δ = (1/(2A)) Σ (cot α + cot β)(x_j - x_i)
+            // so off-diagonals become -h * w / (2A) and the diagonal accumulates +h * Σw / (2A).
+            double coeff = -h * (w / (2.0 * area));
+            if (coeff != 0.0) {
+                triplets.emplace_back(row, neighbor->index, coeff);
+            }
+            he = he->flip->next;
+        } while (he != he_start);
+
+        double diag = 1.0 + h * (weight_sum / (2.0 * area));
+        triplets.emplace_back(row, row, diag);
+    }
+
+    Eigen::SparseMatrix<double> F(static_cast<int>(n), static_cast<int>(n));
+    F.setFromTriplets(triplets.begin(), triplets.end());
+    return F;
+}
+
+void update_mesh_from_solution(MeshGeometry& mesh,
+                               const Eigen::VectorXd& x,
+                               const Eigen::VectorXd& y,
+                               const Eigen::VectorXd& z) {
+    for (std::size_t i = 1; i < mesh.hevs.size(); ++i) {
+        HEV* v = mesh.hevs[i];
+        int idx = v->index;
+        v->x = x[idx];
+        v->y = y[idx];
+        v->z = z[idx];
+
+        // keep the original vertex list in sync for rendering
+        mesh.obj.vertices[i].x = v->x;
+        mesh.obj.vertices[i].y = v->y;
+        mesh.obj.vertices[i].z = v->z;
+    }
+}
+
+void apply_implicit_fairing(RenderObject& obj, double h) {
+    if (obj.mesh.hevs.size() <= 1) return;
+
+    Eigen::SparseMatrix<double> F = build_fairing_matrix(obj.mesh, h);
+
+    const std::size_t n = obj.mesh.hevs.size() - 1;
+    Eigen::VectorXd x0(n), y0(n), z0(n);
+    for (std::size_t i = 1; i < obj.mesh.hevs.size(); ++i) {
+        const HEV* v = obj.mesh.hevs[i];
+        int idx = v->index;
+        x0[idx] = v->x;
+        y0[idx] = v->y;
+        z0[idx] = v->z;
+    }
+
+    Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+    solver.compute(F);
+    if (solver.info() != Eigen::Success) {
+        throw std::runtime_error("Failed to factorize fairing matrix");
+    }
+
+    Eigen::VectorXd xh = solver.solve(x0);
+    Eigen::VectorXd yh = solver.solve(y0);
+    Eigen::VectorXd zh = solver.solve(z0);
+
+    if (solver.info() != Eigen::Success) {
+        throw std::runtime_error("Failed to solve fairing system");
+    }
+
+    update_mesh_from_solution(obj.mesh, xh, yh, zh);
+    compute_vertex_normals(obj.mesh);
+}
+
+void build_drawables() {
+    g_drawables.clear();
+    g_drawables.reserve(g_render_objects.size());
+
+    for (const auto& src : g_render_objects) {
+        DrawableObject drawable;
+        drawable.vertices.reserve(src.mesh.obj.faces.size() * 9);
+        drawable.normals.reserve(src.mesh.obj.faces.size() * 9);
+
+        std::copy(std::begin(src.ambient), std::end(src.ambient), drawable.ambient);
+        std::copy(std::begin(src.diffuse), std::end(src.diffuse), drawable.diffuse);
+        std::copy(std::begin(src.specular), std::end(src.specular), drawable.specular);
+        drawable.shininess = src.shininess;
+
+        for (const auto& face : src.mesh.obj.faces) {
+            const Vertex& v1 = src.mesh.obj.vertices.at(face.v1);
+            const Vertex& v2 = src.mesh.obj.vertices.at(face.v2);
+            const Vertex& v3 = src.mesh.obj.vertices.at(face.v3);
+
+            const Vec3f& n1 = src.mesh.vertex_normals.at(face.v1);
+            const Vec3f& n2 = src.mesh.vertex_normals.at(face.v2);
+            const Vec3f& n3 = src.mesh.vertex_normals.at(face.v3);
+
+            const std::array<const Vertex*, 3> verts{&v1, &v2, &v3};
+            const std::array<const Vec3f*, 3> norms{&n1, &n2, &n3};
+
+            for (int i = 0; i < 3; ++i) {
+                drawable.normals.push_back(norms[i]->x);
+                drawable.normals.push_back(norms[i]->y);
+                drawable.normals.push_back(norms[i]->z);
+
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->x));
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->y));
+                drawable.vertices.push_back(static_cast<GLfloat>(verts[i]->z));
+            }
+        }
+
+        g_drawables.push_back(std::move(drawable));
+    }
+}
+
+void init_lights() {
+    glEnable(GL_LIGHTING);
+    glLightModeli(GL_LIGHT_MODEL_LOCAL_VIEWER, GL_TRUE);
+
+    const auto& lights = g_scene.lights;
+    GLint max_lights = 0;
+    glGetIntegerv(GL_MAX_LIGHTS, &max_lights);
+    GLfloat zero4[4]  = { 0.f, 0.f, 0.f, 1.f };
+
+    for (GLint i = 0; i < max_lights; ++i) {
+        GLenum light_id = static_cast<GLenum>(GL_LIGHT0 + i);
+        if (i < static_cast<GLint>(lights.size())) {
+            const auto& light = lights[i];
+            glEnable(light_id);
+            GLfloat color[4] = {
+                static_cast<GLfloat>(light.r),
+                static_cast<GLfloat>(light.g),
+                static_cast<GLfloat>(light.b),
+                1.0f
+            };
+            glLightfv(light_id, GL_DIFFUSE, color);
+            glLightfv(light_id, GL_SPECULAR, color);
+            glLightfv(light_id, GL_AMBIENT, zero4);
+            glLightf(light_id, GL_QUADRATIC_ATTENUATION, static_cast<GLfloat>(light.atten));
+        } else {
+            glDisable(light_id);
+        }
+    }
+
+    GLfloat color[4] = {1.f, 1.f, 1.f, 1.f};
+    glLightModelfv(GL_LIGHT_MODEL_AMBIENT, color);
+}
+
+void init_gl() {
+    glShadeModel(GL_SMOOTH);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_NORMALIZE);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glEnableClientState(GL_NORMAL_ARRAY);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadMatrixd(g_scene.cam_transforms.P.data());
+
+    glMatrixMode(GL_MODELVIEW);
+    init_lights();
+}
+
+void set_lights() {
+    const auto& lights = g_scene.lights;
+    int num_lights = static_cast<int>(lights.size());
+
+    for(int i = 0; i < num_lights; ++i)
+    {
+        const auto& light = lights[i];
+        GLfloat position[4] = {
+            static_cast<GLfloat>(light.x),
+            static_cast<GLfloat>(light.y),
+            static_cast<GLfloat>(light.z),
+            1.0f
+        };
+        int light_id = GL_LIGHT0 + i;
+        glLightfv(light_id, GL_POSITION, position);
+    }
+}
+
+void draw_scene() {
+    for (const auto& drawable : g_drawables) {
+        glMaterialfv(GL_FRONT, GL_AMBIENT, drawable.ambient);
+        glMaterialfv(GL_FRONT, GL_DIFFUSE, drawable.diffuse);
+        glMaterialfv(GL_FRONT, GL_SPECULAR, drawable.specular);
+        glMaterialf(GL_FRONT, GL_SHININESS, drawable.shininess);
+
+        glVertexPointer(3, GL_FLOAT, 0, drawable.vertices.data());
+        glNormalPointer(GL_FLOAT, 0, drawable.normals.data());
+        const GLsizei vertexCount = static_cast<GLsizei>(drawable.vertices.size() / 3);
+        glDrawArrays(GL_TRIANGLES, 0, vertexCount);
+    }
+}
+
+void display() {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glLoadIdentity();
+
+    glMultMatrixd(g_scene.cam_transforms.Cinv.data());
+
+    auto arcball_matrix = g_arcball.rotation().to_matrix();
+    glMultMatrixd(arcball_matrix.data());
+
+    set_lights();
+    draw_scene();
+
+    glutSwapBuffers();
+}
+
+static double camera_aspect_from_P(const Eigen::Matrix4d& P) {
+    return P(1,1) / P(0,0);
+}
+
+void apply_letterboxed_viewport(int win_w, int win_h) {
+    const double A_cam = camera_aspect_from_P(g_scene.cam_transforms.P);
+    const double A_win = static_cast<double>(win_w) / static_cast<double>(win_h);
+
+    int vx = 0, vy = 0, vw = win_w, vh = win_h;
+    if (A_win > A_cam) {
+        vw = static_cast<int>(std::round(vh * A_cam));
+        vx = (win_w - vw) / 2;
+    } else if (A_win < A_cam) {
+        vh = static_cast<int>(std::round(vw / A_cam));
+        vy = (win_h - vh) / 2;
+    }
+    glViewport(vx, vy, vw, vh);
+}
+
+void reshape(int width, int height) {
+    g_window_width = std::max(width, 1);
+    g_window_height = std::max(height, 1);
+    apply_letterboxed_viewport(g_window_width, g_window_height);
+    g_arcball.set_window(g_window_width, g_window_height);
+    glutPostRedisplay();
+}
+
+void mouse(int button, int state, int x, int y) {
+    if (button == GLUT_LEFT_BUTTON) {
+        if (state == GLUT_DOWN) {
+            g_arcball.begin_drag(x, y);
+        } else if (state == GLUT_UP) {
+            g_arcball.end_drag();
+        }
+        glutPostRedisplay();
+    }
+}
+
+void motion(int x, int y) {
+    g_arcball.update_drag(x, y);
+    glutPostRedisplay();
+}
+
+void run_fairing() {
+    for (auto& obj : g_render_objects) {
+        apply_implicit_fairing(obj, g_time_step);
+    }
+    build_drawables();
+    glutPostRedisplay();
+}
+
+void keyboard(unsigned char key, int, int) {
+    if (key == 27 || key == 'q' || key == 'Q') {
+        std::exit(0);
+    } else if (key == 'f' || key == 'F') {
+        run_fairing();
+    }
+}
+
+RenderObject make_render_object(const ObjectInstance& inst) {
+    RenderObject obj;
+    obj.mesh.obj = inst.obj;
+
+    obj.mesh.vertex_ptrs.reserve(obj.mesh.obj.vertices.size());
+    for (std::size_t i = 0; i < obj.mesh.obj.vertices.size(); ++i) {
+        obj.mesh.vertex_ptrs.push_back(&obj.mesh.obj.vertices[i]);
+    }
+
+    obj.mesh.face_ptrs.reserve(obj.mesh.obj.faces.size());
+    for (std::size_t i = 0; i < obj.mesh.obj.faces.size(); ++i) {
+        obj.mesh.face_ptrs.push_back(&obj.mesh.obj.faces[i]);
+    }
+
+    Mesh_Data mesh_data;
+    mesh_data.vertices = &obj.mesh.vertex_ptrs;
+    mesh_data.faces = &obj.mesh.face_ptrs;
+
+    if (!build_HE(&mesh_data, &obj.mesh.hevs, &obj.mesh.hefs)) {
+        throw std::runtime_error("Failed to build halfedge structure");
+    }
+
+    for (std::size_t i = 1; i < obj.mesh.hevs.size(); ++i) {
+        obj.mesh.hevs[i]->index = static_cast<int>(i - 1);
+    }
+
+    auto fill_material = [](const Eigen::Vector3d& src, GLfloat out[4]) {
+        out[0] = static_cast<GLfloat>(src[0]);
+        out[1] = static_cast<GLfloat>(src[1]);
+        out[2] = static_cast<GLfloat>(src[2]);
+        out[3] = 1.0f;
+    };
+
+    fill_material(inst.ambient, obj.ambient);
+    fill_material(inst.diffuse, obj.diffuse);
+    fill_material(inst.specular, obj.specular);
+    double shininess = std::max(0.0, std::min(inst.shininess, 128.0));
+    obj.shininess = static_cast<GLfloat>(shininess);
+
+    compute_vertex_normals(obj.mesh);
+    return obj;
+}
+
+void build_render_objects() {
+    g_render_objects.clear();
+    g_render_objects.reserve(g_scene.scene_objects.size());
+    for (const auto& inst : g_scene.scene_objects) {
+        g_render_objects.push_back(make_render_object(inst));
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 5) {
+        std::cerr << "Usage: " << argv[0] << " [scene_description_file.txt] [xres] [yres] [h]\n";
+        return 1;
+    }
+
+    const std::size_t xres = parse_size_t(argv[2]);
+    const std::size_t yres = parse_size_t(argv[3]);
+    g_time_step = std::stod(argv[4]);
+
+    std::ifstream fin(argv[1]);
+    if (!fin) {
+        std::cerr << "Could not open file: " << argv[1] << "\n";
+        return 1;
+    }
+
+    try {
+        g_scene = parse_scene_file(fin, parse_parent_path(argv[1]));
+    } catch (const std::exception& e) {
+        std::cerr << "Error parsing scene: " << e.what() << "\n";
+        return 1;
+    }
+
+    g_window_width = static_cast<int>(xres);
+    g_window_height = static_cast<int>(yres);
+    g_arcball.set_window(g_window_width, g_window_height);
+
+    build_render_objects();
+    build_drawables();
+
+    glutInit(&argc, argv);
+    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+    glutInitWindowSize(g_window_width, g_window_height);
+    glutInitWindowPosition(0, 0);
+    glutCreateWindow("Implicit Fairing");
+
+#ifdef __APPLE__
+    glewExperimental = GL_TRUE;
+#endif
+    GLenum err = glewInit();
+    if (err != GLEW_OK) {
+        std::cerr << "GLEW init error: " << glewGetErrorString(err) << "\n";
+        return 1;
+    }
+
+    init_gl();
+
+    glutDisplayFunc(display);
+    glutReshapeFunc(reshape);
+    glutMouseFunc(mouse);
+    glutMotionFunc(motion);
+    glutKeyboardFunc(keyboard);
+
+    glutMainLoop();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add OpenGL smooth renderer that parses HW5 scenes and builds halfedge geometry
- implement cotangent-based implicit fairing with Eigen sparse solver and per-vertex normals
- document build instructions and fairing operator details

## Testing
- cmake -S . -B build *(fails: OpenGL libraries not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c060e0abc8322aa731850ecec9806)