### PR TITLE
Implement HW6 Part2 keyframe animation and bunny interpolation

### DIFF
--- a/hw6/Part2/Bunny_Frames/Makefile
+++ b/hw6/Part2/Bunny_Frames/Makefile
@@ -1,0 +1,17 @@
+CC = g++
+CFLAGS = -g -std=c++14
+
+SOURCES = $(wildcard *.cpp)
+EXENAME = bunny_interpolate
+
+INCLUDE := -I../..
+
+all: $(EXENAME)
+
+$(EXENAME): $(SOURCES)
+	$(CC) $(CFLAGS) -o $(EXENAME) $(SOURCES) $(INCLUDE)
+
+clean:
+	rm -f $(EXENAME) *.o
+
+.PHONY: all clean

--- a/hw6/Part2/Bunny_Frames/interpolate_bunny.cpp
+++ b/hw6/Part2/Bunny_Frames/interpolate_bunny.cpp
@@ -1,0 +1,120 @@
+/* CS/CNS 171 -- HW6 Part 2
+ * Interpolates missing bunny frames using Catmull-Rom splines.
+ */
+#include <Eigen/Dense>
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <vector>
+
+template <typename T>
+T catmullRom(const T &p0, const T &p1, const T &p2, const T &p3, float t) {
+    float t2 = t * t;
+    float t3 = t2 * t;
+    return 0.5f * ((2.f * p1) + (-p0 + p2) * t +
+                   (2.f * p0 - 5.f * p1 + 4.f * p2 - p3) * t2 +
+                   (-p0 + 3.f * p1 - 3.f * p2 + p3) * t3);
+}
+
+struct ObjData {
+    std::vector<Eigen::Vector3f> vertices;
+    std::vector<std::string> otherLines;
+};
+
+ObjData readObj(const std::string &filename) {
+    ObjData data;
+    std::ifstream in(filename.c_str());
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.size() > 1 && line[0] == 'v' && line[1] == ' ') {
+            std::stringstream ss(line);
+            char v;
+            Eigen::Vector3f vert;
+            ss >> v >> vert[0] >> vert[1] >> vert[2];
+            data.vertices.push_back(vert);
+        } else {
+            data.otherLines.push_back(line);
+        }
+    }
+    return data;
+}
+
+void writeObj(const std::string &filename, const std::vector<Eigen::Vector3f> &vertices,
+              const std::vector<std::string> &otherLines) {
+    std::ofstream out(filename.c_str());
+    out << std::setprecision(7);
+    for (const auto &v : vertices) {
+        out << "v " << v[0] << " " << v[1] << " " << v[2] << "\n";
+    }
+    for (const auto &line : otherLines) {
+        out << line << "\n";
+    }
+}
+
+Eigen::Vector3f interpolateVertex(int frame, const std::map<int, std::vector<Eigen::Vector3f>> &keyframes,
+                                  int index) {
+    int f0, f1, f2, f3;
+    if (frame < 5) {
+        f0 = 0; f1 = 0; f2 = 5; f3 = 10;
+    } else if (frame < 10) {
+        f0 = 0; f1 = 5; f2 = 10; f3 = 15;
+    } else if (frame < 15) {
+        f0 = 5; f1 = 10; f2 = 15; f3 = 20;
+    } else {
+        f0 = 10; f1 = 15; f2 = 20; f3 = 20;
+    }
+
+    float t = static_cast<float>(frame - f1) / static_cast<float>(f2 - f1);
+    const Eigen::Vector3f &p0 = keyframes.at(f0)[index];
+    const Eigen::Vector3f &p1 = keyframes.at(f1)[index];
+    const Eigen::Vector3f &p2 = keyframes.at(f2)[index];
+    const Eigen::Vector3f &p3 = keyframes.at(f3)[index];
+
+    return catmullRom(p0, p1, p2, p3, t);
+}
+
+int main() {
+    std::vector<int> frameIds = {0, 5, 10, 15, 20};
+    std::map<int, std::vector<Eigen::Vector3f>> keyframes;
+    std::vector<std::string> otherLines;
+
+    for (int id : frameIds) {
+        std::stringstream ss;
+        ss << "keyframes/bunny" << std::setfill('0') << std::setw(2) << id << ".obj";
+        ObjData data = readObj(ss.str());
+        if (keyframes.empty()) {
+            otherLines = data.otherLines;
+        }
+        keyframes[id] = data.vertices;
+    }
+
+    if (keyframes.empty()) {
+        std::cerr << "Failed to load keyframes." << std::endl;
+        return 1;
+    }
+
+    mkdir("generated_frames", 0777);
+
+    std::vector<int> targets = {1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19};
+    size_t vertexCount = keyframes.begin()->second.size();
+
+    for (int frame : targets) {
+        std::vector<Eigen::Vector3f> verts(vertexCount);
+        for (size_t i = 0; i < vertexCount; ++i) {
+            verts[i] = interpolateVertex(frame, keyframes, static_cast<int>(i));
+        }
+
+        std::stringstream ss;
+        ss << "generated_frames/bunny" << std::setfill('0') << std::setw(2) << frame << ".obj";
+        writeObj(ss.str(), verts, otherLines);
+        std::cout << "Wrote frame " << frame << std::endl;
+    }
+
+    return 0;
+}

--- a/hw6/Part2/I_Bar/Makefile
+++ b/hw6/Part2/I_Bar/Makefile
@@ -1,0 +1,39 @@
+###############################################################################
+# CS/CNS 171 Fall 2015 -- **MODIFIED FOR MAC**
+# Template Makefile for OpenGL programs.
+###############################################################################
+CC     = g++
+CFLAGS = -g -std=c++14
+
+SOURCES = $(wildcard *.cpp)
+EXENAME = keyframe
+
+UNAME_S := $(shell uname -s)
+
+INCLUDE := -I../..
+LIBDIR  :=
+LIBS    :=
+
+ifeq ($(UNAME_S),Darwin)  # macOS
+    BREW_PREFIX := $(shell brew --prefix)
+
+    INCLUDE += -I$(BREW_PREFIX)/include
+    LIBDIR  += -L$(BREW_PREFIX)/lib
+
+    LIBS += -lGLEW -framework OpenGL -framework GLUT
+else  # assume Linux
+    INCLUDE += -I/usr/X11R6/include -I/usr/include/GL -I/usr/include
+    LIBDIR  += -L/usr/X11R6/lib -L/usr/local/lib
+
+    LIBS += -lGLEW -lGL -lGLU -lglut -lm
+endif
+
+all: $(EXENAME)
+
+$(EXENAME): $(SOURCES)
+	$(CC) $(CFLAGS) -o $(EXENAME) $(SOURCES) $(INCLUDE) $(LIBDIR) $(LIBS)
+
+clean:
+	rm -f *.o $(EXENAME)
+
+.PHONY: all clean

--- a/hw6/Part2/I_Bar/keyframe.cpp
+++ b/hw6/Part2/I_Bar/keyframe.cpp
@@ -1,0 +1,249 @@
+/* CS/CNS 171 -- HW6 Part 2
+ * Keyframe animation of the I-Bar using Catmull-Rom interpolation.
+ */
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
+#include <GL/glew.h>
+#include <GL/glut.h>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+struct Keyframe {
+    int frame = 0;
+    Eigen::Vector3f translation = Eigen::Vector3f::Zero();
+    Eigen::Vector3f scale = Eigen::Vector3f::Ones();
+    Eigen::Quaternionf rotation = Eigen::Quaternionf::Identity();
+};
+
+std::vector<Keyframe> keyframes;
+int totalFrames = 0;
+int currentFrame = 0;
+GLUquadricObj *quadratic = nullptr;
+
+// Catmull-Rom spline interpolation for vectors/quaternions.
+template <typename T>
+T catmullRom(const T &p0, const T &p1, const T &p2, const T &p3, float t) {
+    float t2 = t * t;
+    float t3 = t2 * t;
+    return 0.5f * ((2.f * p1) + (-p0 + p2) * t +
+                   (2.f * p0 - 5.f * p1 + 4.f * p2 - p3) * t2 +
+                   (-p0 + 3.f * p1 - 3.f * p2 + p3) * t3);
+}
+
+Keyframe interpolateFrame(int frameIdx) {
+    if (keyframes.empty()) {
+        return Keyframe();
+    }
+
+    // Ensure keyframes are sorted by frame index.
+    std::sort(keyframes.begin(), keyframes.end(),
+              [](const Keyframe &a, const Keyframe &b) { return a.frame < b.frame; });
+
+    int n = static_cast<int>(keyframes.size());
+    int idx1 = 0;
+    for (int i = 0; i < n; ++i) {
+        if (frameIdx >= keyframes[i].frame) {
+            idx1 = i;
+        } else {
+            break;
+        }
+    }
+
+    int idx2 = (idx1 + 1) % n;
+    const Keyframe &k1 = keyframes[idx1];
+    const Keyframe &k2 = keyframes[idx2];
+
+    float f1 = static_cast<float>(k1.frame);
+    float f2 = static_cast<float>(k2.frame);
+    float frameValue = static_cast<float>(frameIdx);
+
+    // Handle looping from last keyframe back to the first.
+    if (idx2 == 0) {
+        f2 += static_cast<float>(totalFrames);
+        if (frameIdx < k1.frame) {
+            frameValue += static_cast<float>(totalFrames);
+        }
+    }
+
+    float t = (frameValue - f1) / (f2 - f1);
+
+    const Keyframe &k0 = keyframes[(idx1 - 1 + n) % n];
+    const Keyframe &k3 = keyframes[(idx2 + 1) % n];
+
+    Keyframe result;
+    result.translation = catmullRom(k0.translation, k1.translation, k2.translation, k3.translation, t);
+    result.scale = catmullRom(k0.scale, k1.scale, k2.scale, k3.scale, t);
+
+    Eigen::Vector4f q0 = k0.rotation.coeffs();
+    Eigen::Vector4f q1 = k1.rotation.coeffs();
+    Eigen::Vector4f q2 = k2.rotation.coeffs();
+    Eigen::Vector4f q3 = k3.rotation.coeffs();
+    Eigen::Vector4f qInterp = catmullRom(q0, q1, q2, q3, t);
+    Eigen::Quaternionf q;
+    q.coeffs() = qInterp;
+    q.normalize();
+    result.rotation = q;
+
+    result.frame = frameIdx;
+    return result;
+}
+
+bool loadScript(const std::string &filename) {
+    std::ifstream infile(filename.c_str());
+    if (!infile) {
+        std::cerr << "Failed to open script file: " << filename << std::endl;
+        return false;
+    }
+
+    keyframes.clear();
+    infile >> totalFrames;
+    std::string token;
+    while (infile >> token) {
+        if (token != "Frame") {
+            break;
+        }
+        Keyframe kf;
+        infile >> kf.frame;
+
+        std::string label;
+        infile >> label >> kf.translation[0] >> kf.translation[1] >> kf.translation[2];
+        infile >> label >> kf.scale[0] >> kf.scale[1] >> kf.scale[2];
+
+        float axisX, axisY, axisZ, angleDeg;
+        infile >> label >> axisX >> axisY >> axisZ >> angleDeg;
+        float angleRad = angleDeg * static_cast<float>(M_PI) / 180.0f;
+        Eigen::Vector3f axis(axisX, axisY, axisZ);
+        if (axis.norm() < 1e-6f) {
+            axis = Eigen::Vector3f::UnitX();
+        } else {
+            axis.normalize();
+        }
+        kf.rotation = Eigen::AngleAxisf(angleRad, axis);
+
+        keyframes.push_back(kf);
+    }
+
+    std::sort(keyframes.begin(), keyframes.end(),
+              [](const Keyframe &a, const Keyframe &b) { return a.frame < b.frame; });
+
+    return !keyframes.empty();
+}
+
+void drawIBar() {
+    float cyRad = 0.2f, cyHeight = 1.0f;
+    int quadStacks = 4, quadSlices = 4;
+
+    glPushMatrix();
+    glColor3f(0, 0, 1);
+    glTranslatef(0, cyHeight, 0);
+    glRotatef(90, 1, 0, 0);
+    gluCylinder(quadratic, cyRad, cyRad, 2.0f * cyHeight, quadSlices, quadStacks);
+    glPopMatrix();
+
+    glPushMatrix();
+    glColor3f(0, 1, 1);
+    glTranslatef(0, cyHeight, 0);
+    glRotatef(90, 0, 1, 0);
+    gluCylinder(quadratic, cyRad, cyRad, cyHeight, quadSlices, quadStacks);
+    glPopMatrix();
+
+    glPushMatrix();
+    glColor3f(1, 0, 1);
+    glTranslatef(0, cyHeight, 0);
+    glRotatef(-90, 0, 1, 0);
+    gluCylinder(quadratic, cyRad, cyRad, cyHeight, quadSlices, quadStacks);
+    glPopMatrix();
+
+    glPushMatrix();
+    glColor3f(1, 1, 0);
+    glTranslatef(0, -cyHeight, 0);
+    glRotatef(-90, 0, 1, 0);
+    gluCylinder(quadratic, cyRad, cyRad, cyHeight, quadSlices, quadStacks);
+    glPopMatrix();
+
+    glPushMatrix();
+    glColor3f(0, 1, 0);
+    glTranslatef(0, -cyHeight, 0);
+    glRotatef(90, 0, 1, 0);
+    gluCylinder(quadratic, cyRad, cyRad, cyHeight, quadSlices, quadStacks);
+    glPopMatrix();
+}
+
+void display() {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    gluLookAt(0.0, 0.0, 40.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+
+    Keyframe kf = interpolateFrame(currentFrame);
+
+    glTranslatef(kf.translation[0], kf.translation[1], kf.translation[2]);
+    Eigen::AngleAxisf aa(kf.rotation);
+    float angleDeg = aa.angle() * 180.0f / static_cast<float>(M_PI);
+    Eigen::Vector3f axis = aa.axis();
+    glRotatef(angleDeg, axis[0], axis[1], axis[2]);
+    glScalef(kf.scale[0], kf.scale[1], kf.scale[2]);
+
+    drawIBar();
+
+    glutSwapBuffers();
+}
+
+void reshape(int w, int h) {
+    glViewport(0, 0, w, h);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glFrustum(-1.0, 1.0, -1.0, 1.0, 1.0, 60.0);
+    glMatrixMode(GL_MODELVIEW);
+}
+
+void keyboard(unsigned char key, int, int) {
+    // Step forward one frame on any key press.
+    currentFrame = (currentFrame + 1) % totalFrames;
+    glutPostRedisplay();
+}
+
+void initGL() {
+    glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
+    glEnable(GL_DEPTH_TEST);
+
+    quadratic = gluNewQuadric();
+}
+
+int main(int argc, char **argv) {
+    std::string scriptFile = "test.script";
+    if (argc > 1) {
+        scriptFile = argv[1];
+    }
+
+    if (!loadScript(scriptFile)) {
+        return 1;
+    }
+
+    glutInit(&argc, argv);
+    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+    glutInitWindowSize(800, 600);
+    glutCreateWindow("I-Bar Keyframe");
+
+#ifndef __APPLE__
+    glewInit();
+#endif
+
+    initGL();
+
+    glutDisplayFunc(display);
+    glutKeyboardFunc(keyboard);
+    glutReshapeFunc(reshape);
+
+    glutMainLoop();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add OpenGL keyframe animator for the I-bar using Catmull-Rom interpolation of transforms
- introduce command-line tool to generate missing bunny frames via spline interpolation of vertex positions
- provide makefiles for building both Part 2 programs with Eigen and platform-specific OpenGL settings

## Testing
- make (in hw6/Part2/Bunny_Frames)
- ./bunny_interpolate
- make clean (in hw6/Part2/Bunny_Frames)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926479b57fc8322b37ea3367044dcd1)